### PR TITLE
fix: update context-doctor link to public repo (Zhenyu98/context-doctor)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -33,7 +33,7 @@
 | [DSH-UI4A](https://github.com/dsh-external/DSH-UI4A) | UI4A（UI for Agent）的 DSH 实现（macaron-ui4a-interactive-ai） |
 | [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) | 右侧侧边栏增强：文件预览/终端/Git，可拖拽自定义位置 |
 | [chat-width](https://github.com/dsh-external/chat-width) | 自由调节正文与输入框的展示宽度 |
-| [context-doctor](https://github.com/dsh-external/context-doctor) | DSH 上下文注入审计插件：统计 AGENTS.md 指令链 |
+| [context-doctor](https://github.com/Zhenyu98/context-doctor) | DSH 上下文注入审计插件：统计 AGENTS.md 指令链 |
 | [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) | 跨 Harness 引用 codex / claude code 的历史对话 |
 | [deepseek-manners](https://github.com/dsh-external/deepseek-manners) | 给每次消息后注入感谢语（deepseek-manners） |
 | [distill](https://github.com/dsh-external/distill) | 自动对话蒸馏：后台 subagent 反省 + 技能 create/update |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Restart `dsh web` after installing a bundle plugin. Management panel: Settings â
 
 ## Recently Added
 
-- [context-doctor](https://github.com/dsh-external/context-doctor) - Audit the AGENTS.md instruction chain injected into DSH context.
+- [context-doctor](https://github.com/Zhenyu98/context-doctor) - Audit the AGENTS.md instruction chain injected into DSH context.
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern migration and next-generation agent roleplay for DSH.
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC canvas plugin (cordis).
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,7 +56,7 @@
 
 ## Recently Added
 
-- [context-doctor](https://github.com/dsh-external/context-doctor) - DSH 上下文注入审计：统计 AGENTS.md 指令链。
+- [context-doctor](https://github.com/Zhenyu98/context-doctor) - DSH 上下文注入审计：统计 AGENTS.md 指令链。
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern 迁移与下一代 DSH Agent RP。
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC 画布插件（cordis）。
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - better-sidebar 的 Office 集成。


### PR DESCRIPTION
## 变更内容

context-doctor 插件已从 `dsh-external` 组织转移到个人账号 `Zhenyu98` 并转为公开仓库，本 PR 将 3 处引用同步更新：

- `README.md` — Recently Added 列表
- `README.zh-CN.md` — 最近更新列表
- `CATALOG.md` — 插件目录表

`dsh-external/context-doctor` → `Zhenyu98/context-doctor`（旧地址会自动重定向，但更新为公开地址更准确）

## 影响范围

仅修改 context-doctor 一个条目的链接，其他插件条目未动。