### PR TITLE
docs: enrich context-doctor description (full scope + value proposition)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -33,7 +33,7 @@
 | [DSH-UI4A](https://github.com/dsh-external/DSH-UI4A) | UI4A（UI for Agent）的 DSH 实现（macaron-ui4a-interactive-ai） |
 | [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) | 右侧侧边栏增强：文件预览/终端/Git，可拖拽自定义位置 |
 | [chat-width](https://github.com/dsh-external/chat-width) | 自由调节正文与输入框的展示宽度 |
-| [context-doctor](https://github.com/Zhenyu98/context-doctor) | DSH 上下文注入审计插件：统计 AGENTS.md 指令链 |
+| [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) | 上下文注入审计：指令链/技能目录/工具 schema 的 token 成本量化 + 重复/冲突检测 + 裁剪建议（Web 圆环 + context_audit） |
 | [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) | 跨 Harness 引用 codex / claude code 的历史对话 |
 | [deepseek-manners](https://github.com/dsh-external/deepseek-manners) | 给每次消息后注入感谢语（deepseek-manners） |
 | [distill](https://github.com/dsh-external/distill) | 自动对话蒸馏：后台 subagent 反省 + 技能 create/update |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Restart `dsh web` after installing a bundle plugin. Management panel: Settings â
 
 ## Recently Added
 
-- [context-doctor](https://github.com/Zhenyu98/context-doctor) - Audit the AGENTS.md instruction chain injected into DSH context.
+- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - See exactly what every request carries: token cost of the AGENTS.md chain, skill catalog and tool schemas, with duplicate/conflict detection and actionable pruning tips (Web UI gauge + context_audit tool).
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern migration and next-generation agent roleplay for DSH.
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC canvas plugin (cordis).
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -56,7 +56,7 @@
 
 ## Recently Added
 
-- [context-doctor](https://github.com/Zhenyu98/context-doctor) - DSH 上下文注入审计：统计 AGENTS.md 指令链。
+- [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - 看清模型每个请求到底背着多少上下文：指令链/技能目录/工具 schema 的 token 成本逐项量化，自动检测重复与冲突，给出可执行裁剪建议（Web 圆环面板 + context_audit 工具，全程只读）。
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern 迁移与下一代 DSH Agent RP。
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC 画布插件（cordis）。
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - better-sidebar 的 Office 集成。


### PR DESCRIPTION
## 变更内容

改进 awesome 列表中 context-doctor 条目的描述。原描述只提到 AGENTS.md 指令链审计，与实际能力不符且缺乏吸引力：

**实际能力**：token 成本逐项量化（指令链 / 技能目录 / 工具 schema / MCP）、跨文件重复段落检测、冗余技能检测、rank shadow 冲突检测、按严重度排序的可执行裁剪建议；Web UI 圆环面板 + `context_audit` 模型工具，全程只读。

**新描述**（README / README.zh-CN / CATALOG 三处同步）：

- EN: *See exactly what every request carries: token cost of the AGENTS.md chain, skill catalog and tool schemas, with duplicate/conflict detection and actionable pruning tips (Web UI gauge + context_audit tool).*
- 中文：*看清模型每个请求到底背着多少上下文：指令链/技能目录/工具 schema 的 token 成本逐项量化，自动检测重复与冲突，给出可执行裁剪建议（Web 圆环面板 + context_audit 工具，全程只读）。*

## 说明

- 链接保持 `Zhenyu98/context-doctor`（PR #2 已合并，不重复修改）
- 仅修改 context-doctor 一条目的描述，其他条目未动