### PR TITLE
docs: add dsh-chat-import

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Management panel: Settings → Plugins.
 - [dsh-input-history](https://github.com/dsh-external/dsh-input-history) - Input history.
 - [dsh-multimedia-webui-input](https://github.com/dsh-external/dsh-multimedia-webui-input) - Multimedia file/folder input.
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Office file read/write bundle: model edits Office files, docx/pdf preview in web client.
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import Claude Code JSONL transcripts (tool history + thinking blocks) as resumable DeepSeek Harness sessions.
 
 ## UI & Experience
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -128,6 +128,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-input-history](https://github.com/dsh-external/dsh-input-history) - 输入历史
 - [dsh-multimedia-webui-input](https://github.com/dsh-external/dsh-multimedia-webui-input) - 多媒体文件/文件夹输入
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Office 文件读写 bundle：模型读写 Office 文件，docx/pdf 预览
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - 从 Claude Code JSONL 全保真导入历史会话（含工具调用/思考块），导入后可在 DSH 续聊
 
 ## UI & Experience
 


### PR DESCRIPTION
## 收录请求

- 仓库: https://github.com/Nwflower/dsh-chat-import
- 分类: Input & Editing（英文 + 中文同 PR，符合 contributing.md）
- 功能: 把 Claude Code JSONL transcript 全保真导入为可 resume 的 DSH 会话（tool/call + tool/result、thinking、多步消息），按 cwd 自动挂接工作区
- 说明: 已带 dsh-plugin topic，出现在 CATALOG.md；本次补入手精选列表
- 依赖面: 仅 host 公开服务（sessionPersistence / fs / tools / workspaceRegistry），@deepseek-ai/dsh-tools 已声明 peerDependencies
- 测试: npm test 18/18；2026-08 于 dsh 0.1.0-rc.6 web profile 实测 导入→resume→归组