### PR TITLE
docs: add dsh-mcp-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Management panel: Settings → Plugins.
 - [toybox](https://github.com/dsh-external/toybox) - MCP plugin collection (almanac/bug-tamer/naming master/time capsule, etc.).
 - [dsh-github-integration](https://github.com/dsh-external/dsh-github-integration) - GitHub integration plugin.
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - Super-injector (cordis).
+- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth; tools registered as mcp__<name>__*.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,6 +221,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [toybox](https://github.com/dsh-external/toybox) - MCP 插件集（almanac/bug-tamer/命名大师/时间胶囊等）
 - [dsh-github-integration](https://github.com/dsh-external/dsh-github-integration) - GitHub 集成插件
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - super-injector 插件（cordis）
+- [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP 服务器管理器：设置页添加服务器，OAuth（PKCE + 动态客户端注册）或静态 token 认证，工具注册为 mcp__<name>__*
 
 ## Related
 


### PR DESCRIPTION
Adds [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) to **Infrastructure & Development** in both language versions.

A public, installable DSH profile plugin: an MCP server manager with a Settings → MCP page. Per-server OAuth (authorization code + PKCE, RFC 7591 dynamic client registration, refresh-token rotation, auto-reconnect) or static Bearer token; registers each server's tools as native `mcp__<name>__*` tools using the same naming convention as the built-in @deepseek-ai/dsh-mcp-client, which has no OAuth support.

Install: `dsh plugin --profile web add github:hyqhyq3/dsh-mcp-manager` (declares `dsh.bundle.patch`, activates automatically). Verified end-to-end against an OAuth-protected MCP server (dynamic registration → browser login → token exchange → tools/list → tools/call).

Entry follows the standard: repository + one-line description + link, both READMEs updated in the same PR.