### PR TITLE
docs: add billion-context-dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Management panel: Settings → Plugins.
 
 ## Context & Search
 
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) - Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi; the model decides when and what to compress.
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) - Index-free read-only search across dsh/Codex/Claude Code/pi/OpenCode sessions.
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) - Cite past conversations across harnesses.
 - [dsh-session-cluster](https://github.com/dsh-external/dsh-session-cluster) - Session clustering.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -107,6 +107,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Context & Search
 
+- [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) - DeepSeek Harness 的模型驱动上下文压缩（ACP），移植自 billion-context-pi：由模型决定何时压缩、压缩什么。
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) - 跨 dsh/Codex/Claude Code/pi/OpenCode 会话只读搜索，无索引
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) - 跨 harness 引用历史对话
 - [dsh-session-cluster](https://github.com/dsh-external/dsh-session-cluster) - 会话聚类


### PR DESCRIPTION
Add [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) to Context & Search (both EN and zh-CN).

Model-driven context compression (Active Context Pruning / ACP) for DeepSeek Harness, ported from billion-context-pi (ranxianglei) — the model decides when and what to compress, with compress / decompress / search_context / acp_status tools and a CompactionEngine backend. Published on npm as billion-context-dsh.