### PR TITLE
Add dsh-pi-tui: pi-tui terminal front end for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Management panel: Settings → Plugins.
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - Live token estimates and generation TPS.
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS meter.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).
-- [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - pi-tui (differential-rendering terminal framework) front door: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.
+- [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - Pi TUI (differential-rendering terminal framework) front end: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.
 - [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) - Sidebar: file rendering/terminal/Git/subagents/custom APIs.
 - [dsh-web-panel](https://github.com/dsh-external/dsh-web-panel) - Embedded terminal dock + Git Review + file view.
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) - Isolated web page previews with element annotations and visual adjustments that guide source edits.

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Management panel: Settings → Plugins.
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - Live token estimates and generation TPS.
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS meter.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).
+- [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - pi-tui (differential-rendering terminal framework) front door: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.
 - [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) - Sidebar: file rendering/terminal/Git/subagents/custom APIs.
 - [dsh-web-panel](https://github.com/dsh-external/dsh-web-panel) - Embedded terminal dock + Git Review + file view.
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) - Isolated web page previews with element annotations and visual adjustments that guide source edits.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,6 +148,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat 缩略图（cordis）
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - 显示命令具体内容而非描述
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - 官方 UI 插件参考实现
+- [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - 基于 pi-tui 的 DeepSeek Harness 终端前端：流式 Markdown、thinking 折叠、工具卡片、slash 命令、审批/提问交互与 Web 会话共享
 
 ## Browser & Remote
 


### PR DESCRIPTION
Adds [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) — a TUI plugin built on the [pi TUI framework](https://github.com/earendil-works/pi/tree/main/packages/tui) (`@earendil-works/pi-tui`): differential rendering, streaming markdown, thinking collapse, tool cards, slash commands from the official command registry, approval/ask_user_question overlays, and sessions shared with the web profile.