### PR TITLE
docs: add deepseek-harness-desktop

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ Management panel: Settings → Plugins.
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat thumbnails (cordis).
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - Show actual command content instead of descriptions.
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - Official UI plugin reference implementation.
+- [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) - Native Windows desktop shell: 1:1 official web UI with embedded server hosting, tray and auto-recovery.
 
 ## Browser & Remote
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,6 +148,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat 缩略图（cordis）
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - 显示命令具体内容而非描述
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - 官方 UI 插件参考实现
+- [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) - Windows 原生桌面外壳:一比一加载官方 Web UI,内置服务器托管、托盘驻留与掉线自动恢复
 
 ## Browser & Remote
 


### PR DESCRIPTION
Add [chyra-moon/deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) to the UI & Experience category.

Native Windows desktop shell that loads the official DSH web UI 1:1, with embedded server hosting (no manual \
px\), tray, single-instance, crash/offline auto-recovery, and npx fallback. Public repo, MIT, tagged \dsh-plugin\, packaged installers published as GitHub Release v0.1.0.

Entry added to both README.md and README.zh-CN.md per the contribution guide.