### PR TITLE
Add dsh-tool-git (Git & Engineering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Management panel: Settings → Plugins.
 - [dsh-git-identity](https://github.com/dsh-external/dsh-git-identity) - Pin Git commit authorship to the environment identity (gh account + noreply email).
 - [dsh-gh-bridge](https://github.com/dsh-external/dsh-gh-bridge) - Bridge macOS Keychain GitHub token into sandboxed gh.
 - [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) - Auto blame.
+- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - Structured git tools (status/diff/log/branch/stage/commit/stash/show) with a destructive-command guard.
 - [dsh-plugin-check](https://github.com/dsh-external/dsh-plugin-check) - Plugin health checks (manifest/patch format/build pitfalls/hub status).
 - [dsh-inspect](https://github.com/dsh-external/dsh-inspect) - Adversarial checkup → fix → review loop.
 - [dsh-alphasolve](https://github.com/dsh-external/dsh-alphasolve) - AlphaSolve workflow.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -177,6 +177,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-git-identity](https://github.com/dsh-external/dsh-git-identity) - Git 提交固定环境作者身份（gh 登录账号 + noreply 邮箱）
 - [dsh-gh-bridge](https://github.com/dsh-external/dsh-gh-bridge) - macOS Keychain GitHub token 桥入 sandbox gh
 - [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) - 自动 blame
+- [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - 结构化 Git 工具（status/diff/log/branch/stage/commit/stash/show）+ 破坏性命令安全护栏
 - [dsh-plugin-check](https://github.com/dsh-external/dsh-plugin-check) - 插件健康检查（清单/patch 格式/构建陷阱/hub 收录）
 - [dsh-inspect](https://github.com/dsh-external/dsh-inspect) - checkup → fix → review 对抗式闭环
 - [dsh-alphasolve](https://github.com/dsh-external/dsh-alphasolve) - AlphaSolve 工作流


### PR DESCRIPTION
Adds [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) to the **Git & Engineering** category.

- Structured git tools for DeepSeek Harness: `git_status` / `git_diff` / `git_log` / `git_branch` / `git_stage` / `git_commit` / `git_stash` / `git_show`
- `tools/pre-execute` safety gate that denies destructive git operations (force push, hard reset, rebase, amend, branch/tag deletion) through both the plugin's tools and shell tools
- 28 vitest tests, verified loading in a real dsh profile; tagged `dsh-plugin` on GitHub

Both EN and zh-CN entries added.