### PR TITLE
plugin: add dsh-test-runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,4 +242,3 @@ Please have a look at [contributing.md](contributing.md). Entry standard: reposi
 ## Thanks
 
 Thanks to the [Linux Do community](https://linux.do/) for the support and exchange.
-

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Management panel: Settings → Plugins.
 - [mstar-workflow](https://github.com/dsh-external/mstar-workflow) - Workflow engine.
 - [dsh-spur](https://github.com/dsh-external/dsh-spur) - Task engine.
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - Embedded task-management engine.
-- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect vitest/jest/pytest/node:test, run tests, parse failure summaries for the model.
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect Vitest/Jest/pytest/node:test, run tests, parse failure summaries for the model.
 
 ## Notifications & Channels
 

--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Management panel: Settings → Plugins.
 - [mstar-workflow](https://github.com/dsh-external/mstar-workflow) - Workflow engine.
 - [dsh-spur](https://github.com/dsh-external/dsh-spur) - Task engine.
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - Embedded task-management engine.
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect vitest/jest/pytest/node:test, run tests, parse failure summaries for the model.
 
 ## Notifications & Channels
 
@@ -241,3 +242,4 @@ Please have a look at [contributing.md](contributing.md). Entry standard: reposi
 ## Thanks
 
 Thanks to the [Linux Do community](https://linux.do/) for the support and exchange.
+

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,6 +184,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [mstar-workflow](https://github.com/dsh-external/mstar-workflow) - 工作流引擎
 - [dsh-spur](https://github.com/dsh-external/dsh-spur) - 任务引擎
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - 内嵌任务管理引擎
+- [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - 结构化测试运行工具（test_run）：自动识别 Vitest/Jest/pytest/node:test，运行测试并为模型解析失败摘要。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
## dsh-test-runner

Structured test runner tool `test_run`: auto-detect vitest/jest/pytest/node:test/npm script, run tests, parse pass/fail summary + failure names + error messages for the model — avoids reading raw test output.

### Category
Git & Engineering

### Repo
- URL: https://github.com/suimi8/dsh-test-runner
- dsh-plugin topic: yes
- License: MIT

### Compatibility
- mainline: 7b9644f (2026-08)
- verified: Windows + PowerShell executor + node:test (6 tests, 1 intentional failure located + fixed + re-verified green)
- seams: shell / fs / sandboxPolicy / ctx.tools (all stable)
- safe degradation: on parse miss, returns exitCode + output tail (no crash)
- node --check index.js: pass

### Spec compliance
All checked against docs/cookbook/adding-a-tool.md and docs/user/develop/ (see repo README 'spec compliance' section):
- execute contract (canonical value / infra throw / exec.signal)
- UI card hard rules (presentCall/presentResult pure / terminal title is command)
- lifecycle (effect-based registration / inject / isConcurrencySafe)
- packaging (dsh.bundle.patch / cordis.patch.yml by package name)

### Change
Added one line under 'Git & Engineering'.