### PR TITLE
docs: update dsh-pet link to public repo (FlytoMAYDAY80/dsh-pet)

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ Management panel: Settings → Plugins.
 ## Fun & Lifestyle
 
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - Pixel whale companion (blink/tail/spout/hearts).
-- [dsh-pet](https://github.com/dsh-external/dsh-pet) - Desktop whale pet with live session state.
+- [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - Desktop whale pet with live session state.
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - Desktop pet, Rust edition.
 - [dsh-stickers](https://github.com/dsh-external/dsh-stickers) - Stickers.
 - [dsh-ads](https://github.com/dsh-external/dsh-ads) - 2005 Chinese-web-style ad layer (joke plugin).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -205,7 +205,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Fun & Lifestyle
 
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - 像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）
-- [dsh-pet](https://github.com/dsh-external/dsh-pet) - 桌面小鲸鱼，实时感知会话状态
+- [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - 桌面小鲸鱼，实时感知会话状态
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - 桌宠 Rust 版
 - [dsh-stickers](https://github.com/dsh-external/dsh-stickers) - 贴纸
 - [dsh-ads](https://github.com/dsh-external/dsh-ads) - 2005 中文站风格广告层（整活）


### PR DESCRIPTION
## 为什么改

`dsh-external` 组织自 2026 年 8 月起为私有（维护说明中已注明），`dsh-external/dsh-pet` 对普通用户不可访问（404）。项目已随 DeepSeek Harness 发布迁移到公开仓库 `FlytoMAYDAY80/dsh-pet`。

## 改动

- `README.md`：dsh-pet 条目链接更新为 `https://github.com/FlytoMAYDAY80/dsh-pet`
- `README.zh-CN.md`：同上

仅更新链接，描述未改动。