### PR TITLE
docs: add dsh-review-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Management panel: Settings → Plugins.
 - [mstar-workflow](https://github.com/dsh-external/mstar-workflow) - Workflow engine.
 - [dsh-spur](https://github.com/dsh-external/dsh-spur) - Task engine.
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - Embedded task-management engine.
+- [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - Incremental diff reviewer: checkpoint-based since-review queue with a Web UI panel, /review command, and feedback injection into the agent.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,6 +184,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [mstar-workflow](https://github.com/dsh-external/mstar-workflow) - 工作流引擎
 - [dsh-spur](https://github.com/dsh-external/dsh-spur) - 任务引擎
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - 内嵌任务管理引擎
+- [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - 增量代码审查插件：checkpoint 增量队列 + Web 审查面板 + /review 命令，审查意见注入 agent
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Add [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) to the **Git & Engineering** category (both EN and zh-CN).

Incremental diff reviewer for DeepSeek Harness: checkpoint-based since-review queue with a Web UI review panel (docked above the composer), a /review command, and review feedback injected into the agent via agent.inject(). Ships prebuilt bundles; installs with `dsh plugin --profile web add github:wuxiangru915/dsh-review-loop`.