### PR TITLE
Add dsh-doctor to Infrastructure & Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ Management panel: Settings → Plugins.
 - [dsh-github-integration](https://github.com/dsh-external/dsh-github-integration) - GitHub integration plugin.
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - Super-injector (cordis).
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth; tools registered as mcp__<name>__*.
+- [dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Profile health check: finds config fields a patch dropped by whole-config replacement, patches targeting missing entry ids, and tool-name collisions.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -227,6 +227,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-github-integration](https://github.com/dsh-external/dsh-github-integration) - GitHub 集成插件
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - super-injector 插件（cordis）
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP 服务器管理器：设置页添加服务器，OAuth（PKCE + 动态客户端注册）或静态 token 认证，工具注册为 mcp__<name>__*
+- [dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Profile 体检：检出 patch 整体替换 config 而丢失的字段、指向不存在 entry id 的 patch，以及工具重名冲突。
 
 ## Related
 


### PR DESCRIPTION
One entry in both READMEs, following the entry standard (real repo, one factual line, no badges or blurb).

**dsh-doctor** is a read-only health check for a dsh profile. It diffs `dsh --dump-config` against `--dump-default-config`, so findings are attributable to the user's own patch layer rather than upstream defaults.

It exists because two failure modes boot cleanly with exit code 0:

- an id-targeted patch replaces an entry's whole `config`, silently dropping every sibling field the patch does not restate
- a patch targeting an unknown entry id produces one stderr line and then a normal boot, invisible in a Web UI launch

Both verified against `@deepseek-ai/dsh` 0.1.0-rc.5. MIT, zero dependencies, 18 tests, CI on Node 18/20/22.

Happy to move it to a different category or reword the line.