### PR TITLE
docs: add deepseek-harness-tui

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Management panel: Settings → Plugins.
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS meter.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - Pi TUI (differential-rendering terminal framework) front end: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - Rust/ratatui terminal client that speaks the DSH SDK JSON-RPC protocol directly and runs standalone or as a profile bundle.
 - [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) - Sidebar: file rendering/terminal/Git/subagents/custom APIs.
 - [dsh-web-panel](https://github.com/dsh-external/dsh-web-panel) - Embedded terminal dock + Git Review + file view.
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) - Isolated web page previews with element annotations and visual adjustments that guide source edits.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -136,6 +136,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - 实时 token 估算与生成 TPS
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS 仪表
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code 风格全屏 TUI（流式展开/双击 Esc 回滚）
+- [deepseek-harness-tui](https://github.com/openma-ai/deepseek-harness-tui) - Rust/ratatui 终端客户端，直接使用 DSH SDK JSON-RPC 协议，支持独立运行或作为 profile bundle 加载
 - [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) - 侧边栏：文件渲染/终端/Git/子代理/自定义 API
 - [dsh-web-panel](https://github.com/dsh-external/dsh-web-panel) - 内嵌终端 dock + Git Review + 文件视图
 - [dsh-web-review](https://github.com/CanglongCl/dsh-web-review) - 隔离网页预览，通过元素批注和可视化调整指导源码修改


### PR DESCRIPTION
## What changed

Adds `openma-ai/deepseek-harness-tui` to the English and Chinese **UI & Experience** sections.

## Why

The project is a Rust/ratatui terminal client for DeepSeek Harness. It consumes the SDK JSON-RPC protocol directly and can run either standalone or as a `dsh` profile bundle, so it fits the curated DSH UI ecosystem.

## User impact

Readers can discover an additional terminal-native interface for DSH with streamed reasoning, tool events, subagent activity, and durable sessions.

## Checks

- Confirmed the canonical repository is public and documented.
- Confirmed the repository carries the `dsh-plugin` topic.
- Updated both language versions.
- `git diff --check` passes.
