### PR TITLE
Add dshp to Infrastructure & Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ Management panel: Settings → Plugins.
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - Super-injector (cordis).
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth; tools registered as mcp__<name>__*.
 - [dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Profile health check: finds config fields a patch dropped by whole-config replacement, patches targeting missing entry ids, and tool-name collisions.
+- [dshp](https://github.com/asdf17128/dshp) - Profile manager: list, create, clone and diff profiles, and export a whole setup (bundle order, plugin versions, patch) as one portable file.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -232,6 +232,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - super-injector 插件（cordis）
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP 服务器管理器：设置页添加服务器，OAuth（PKCE + 动态客户端注册）或静态 token 认证，工具注册为 mcp__<name>__*
 - [dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Profile 体检：检出 patch 整体替换 config 而丢失的字段、指向不存在 entry id 的 patch，以及工具重名冲突。
+- [dshp](https://github.com/asdf17128/dshp) - Profile 管理器：列出/新建/克隆/对比 profile，并把整套配置（bundle 顺序、插件版本、patch）导出为单个可移植文件。
 
 ## Related
 


### PR DESCRIPTION
Thanks for merging #20.

**dshp** manages dsh profiles: `ls` / `new` / `clone` / `diff`, and exports a whole setup — bundle order, plugin versions and `cordis.patch.yml` — as one portable file that `dshp import` reproduces.

It exists because dsh can boot a profile and forward installs to pnpm, but cannot create an empty one, list what you have, or copy a working setup before you experiment on it.

Verified: exporting a 132-entry profile and importing it into a fresh `$DSH_HOME` reproduces an identical composed tree, patch included. MIT, zero dependencies, 17 tests, CI on Node 18/20/22.