### PR TITLE
Add dsh-balance-meter to Recently Added and UI & Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ Management panel: Settings → Plugins.
 
 ## Recently Added
 
-- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.
 - [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - See exactly what every request carries: token cost of the AGENTS.md chain, skill catalog and tool schemas, with duplicate/conflict detection and actionable pruning tips (Web UI gauge + context_audit tool).
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern migration and next-generation agent roleplay for DSH.
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC canvas plugin (cordis).

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Management panel: Settings → Plugins.
 
 ## Recently Added
 
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - Live DeepSeek account balance and session cost in the DSH Web composer dock, with auto-fetched official pricing and peak/off-peak support.
 - [dsh-context-doctor](https://github.com/Zhenyu98/dsh-context-doctor) - See exactly what every request carries: token cost of the AGENTS.md chain, skill catalog and tool schemas, with duplicate/conflict detection and actionable pruning tips (Web UI gauge + context_audit tool).
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern migration and next-generation agent roleplay for DSH.
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC canvas plugin (cordis).
@@ -135,6 +136,7 @@ Management panel: Settings → Plugins.
 
 ## UI & Experience
 
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek account balance and session cost in the DSH Web composer dock (auto-fetched official pricing, peak/off-peak support).
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - Live token estimates and generation TPS.
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS meter.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -133,6 +133,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## UI & Experience
 
+- [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek 账户余额与当前会话成本显示在 DSH Web 编辑器 dock 中（自动获取官方价格，支持峰时/非峰时计价）。
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - 实时 token 估算与生成 TPS
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS 仪表
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code 风格全屏 TUI（流式展开/双击 Esc 回滚）


### PR DESCRIPTION
Adds dsh-balance-meter to the Recently Added list and the UI & Experience section.

dsh-balance-meter shows the live DeepSeek account balance and current session cost in the DSH Web composer dock, with auto-fetched official pricing (refreshed every 6h) and peak/off-peak hour support. Install via `dsh plugin --profile web add dsh-balance-meter` (npm) or the GitHub repo.