### PR TITLE
docs: add dsh-harness-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Management panel: Settings → Plugins.
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - Mnemonic layer.
 - [dsh-slice-agent-loop](https://github.com/dsh-external/dsh-slice-agent-loop) - Drop-in agent loop with bounded-slice context engine (cordis).
 - [savemoneybenchmark](https://github.com/dsh-external/savemoneybenchmark) - Cost-reduction benchmark (examples + skills).
+- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) - MCP server exposing Harness agent: any MCP client (e.g. Hermes) drives Harness as its 'arms'.
 
 ## Git & Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,6 +175,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - 助记层
 - [dsh-slice-agent-loop](https://github.com/dsh-external/dsh-slice-agent-loop) - Drop-in agent loop：有界 slice 上下文引擎（cordis）
 - [savemoneybenchmark](https://github.com/dsh-external/savemoneybenchmark) - 降本增效 benchmark（examples + skills）
+- [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) - MCP server 暴露 Harness agent：任意 MCP 客户端（如 Hermes）驱动 Harness 当「胳膊」。
 
 ## Git & Engineering
 


### PR DESCRIPTION
Add [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) — a Cordis plugin running an MCP server inside Harness, so any MCP client (e.g. Hermes) can drive Harness to execute coding tasks. Updated both English and Chinese READMEs.