### PR TITLE
docs: add dsh-sticky-note

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Management panel: Settings → Plugins.
 - [dsh-multimedia-webui-input](https://github.com/dsh-external/dsh-multimedia-webui-input) - Multimedia file/folder input.
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Office file read/write bundle: model edits Office files, docx/pdf preview in web client.
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import Claude Code JSONL transcripts (tool history + thinking blocks) as resumable DeepSeek Harness sessions.
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - Quick sticky notes in the composer: ideas/feelings/TODO with Markdown preview, auto-save, one-click send to chat.
 
 ## UI & Experience
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -130,6 +130,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-multimedia-webui-input](https://github.com/dsh-external/dsh-multimedia-webui-input) - 多媒体文件/文件夹输入
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Office 文件读写 bundle：模型读写 Office 文件，docx/pdf 预览
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - 从 Claude Code JSONL 全保真导入历史会话（含工具调用/思考块），导入后可在 DSH 续聊
+- [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - 输入框工具栏快速便签：点子/感想/TODO，Markdown 预览、自动保存、一键发送到对话。
 
 ## UI & Experience
 


### PR DESCRIPTION
Add [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) to the Input & Editing category in both README.md and README.zh-CN.md.

dsh-sticky-note is a quick sticky-note plugin for the DSH composer toolbar: jot ideas/feelings/TODO, auto-save as Markdown, one-click send to chat, with configurable save interval, auto-cleanup and retention.