### PR TITLE
Add dsh-skin: Codex-style skin switcher + custom wallpaper for the Web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Management panel: Settings → Plugins.
 - [dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) - Split panes.
 - [dsh-ui-progress](https://github.com/dsh-external/dsh-ui-progress) - Progress indicators.
 - [dsh-skins](https://github.com/dsh-external/dsh-skins) - Web UI skins.
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex-style skin switcher + custom wallpaper for the Web UI: curated --dsw-alias-* palettes and a translucent wallpaper layer with opacity/blur controls.
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat thumbnails (cordis).
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - Show actual command content instead of descriptions.
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - Official UI plugin reference implementation.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -148,6 +148,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-split-panes](https://github.com/dsh-external/dsh-split-panes) - 分栏
 - [dsh-ui-progress](https://github.com/dsh-external/dsh-ui-progress) - 进度
 - [dsh-skins](https://github.com/dsh-external/dsh-skins) - Web UI 皮肤
+- [dsh-skin](https://github.com/KinGao294/dsh-skin) - Codex 风格换肤 + 自定义背景插件：内置多套 --dsw-alias-* 配色，支持透明度/模糊调节的半透明壁纸层。
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat 缩略图（cordis）
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - 显示命令具体内容而非描述
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - 官方 UI 插件参考实现


### PR DESCRIPTION
## What

Add [dsh-skin](https://github.com/KinGao294/dsh-skin) to the **UI & Experience** category (both EN and zh-CN), right after the existing `dsh-skins` entry.

## Why

dsh-skin is a Web UI plugin that:

- registers 7 curated `--dsw-alias-*` palettes into DSH's theme runtime (one-click skin switching from Settings → General, Codex-style);
- adds a custom wallpaper: a fixed backdrop layer with a translucent main canvas/sidebar (via `ctx.theme.overrideTokens`) and opacity/blur controls;
- persists choices in localStorage; installs with `dsh plugin --profile web add -w dsh-skin`.

Public repo carries the `dsh-plugin` topic and declares `dsh.bundle` + `dsh.client` manifests.