### PR TITLE
docs: add dsh-eval

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,7 @@ Management panel: Settings → Plugins.
 - [dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Profile health check: finds config fields a patch dropped by whole-config replacement, patches targeting missing entry ids, and tool-name collisions.
 - [dshp](https://github.com/asdf17128/dshp) - Profile manager: list, create, clone and diff profiles, and export a whole setup (bundle order, plugin versions, patch) as one portable file.
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data, open scoring model, rank/search/recommend tools and a settings-page leaderboard.
+- [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading, and run compare/report.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -241,6 +241,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-doctor](https://github.com/asdf17128/dsh-doctor) - Profile 体检：检出 patch 整体替换 config 而丢失的字段、指向不存在 entry id 的 patch，以及工具重名冲突。
 - [dshp](https://github.com/asdf17128/dshp) - Profile 管理器：列出/新建/克隆/对比 profile，并把整套配置（bundle 顺序、插件版本、patch）导出为单个可移植文件。
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
+- [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent 评测平台：benchmark YAML、headless dsh 运行、trace 指标、脚本化评分与 run 对比/报告。
 
 ## Related
 


### PR DESCRIPTION
Adds [dsh-eval](https://github.com/hccccc01333/dsh-eval) to Infrastructure & Development in both EN and zh-CN lists.

The dsh ecosystem already has observability/debugging tools (dsh-trace, dsh-tps, dsh-context-doctor) but no dedicated Agent Evaluation Platform; dsh-eval fills that slot: benchmark YAML, headless dsh runs, trace-based metrics (steps/tokens/latency/cost/retry/tool success/invalid tool calls/task success/tool-selection accuracy), JSON/markdown reports, and run comparison.