### PR TITLE
docs: add deepseek-harness-acp

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ Management panel: Settings → Plugins.
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - ExtensionAPI bridge for pi.
 - [dsh-a2a](https://github.com/dsh-external/dsh-a2a) - Agent2Agent mesh.
 - [dsh-acp](https://github.com/dsh-external/dsh-acp) - Client-neutral ACP adapter.
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) - ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while reusing DSH credentials, sessions, and MCP configuration.
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - Mnemonic layer.
 - [dsh-slice-agent-loop](https://github.com/dsh-external/dsh-slice-agent-loop) - Drop-in agent loop with bounded-slice context engine (cordis).
 - [savemoneybenchmark](https://github.com/dsh-external/savemoneybenchmark) - Cost-reduction benchmark (examples + skills).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -175,6 +175,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - pi ExtensionAPI 桥接
 - [dsh-a2a](https://github.com/dsh-external/dsh-a2a) - Agent2Agent mesh
 - [dsh-acp](https://github.com/dsh-external/dsh-acp) - Client-neutral ACP 适配器
+- [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) - ACP profile 插件与独立 server，把完整 DSH agent 接入 Zed 等 ACP 客户端，并复用 DSH 的凭据、会话与 MCP 配置
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - 助记层
 - [dsh-slice-agent-loop](https://github.com/dsh-external/dsh-slice-agent-loop) - Drop-in agent loop：有界 slice 上下文引擎（cordis）
 - [savemoneybenchmark](https://github.com/dsh-external/savemoneybenchmark) - 降本增效 benchmark（examples + skills）


### PR DESCRIPTION
## What changed

Adds `openma-ai/deepseek-harness-acp` to the English and Chinese **Models & Inference** sections.

## Why

This is a DSH profile plugin and standalone ACP server that exposes the full DeepSeek Harness agent to Zed and other ACP clients. Unlike a minimal protocol adapter, it reuses the host's credentials, durable sessions, modes, permissions, MCP configuration, and tool stack.

## User impact

Readers can discover an editor-native way to use their existing DSH runtime and sessions.

## Checks

- Confirmed the canonical repository is public and documented.
- Confirmed `package.json` declares `dsh.bundle.patch`.
- Confirmed the repository carries the `dsh-plugin` topic.
- Updated both language versions.
- `git diff --check` passes.
