### PR TITLE
docs: add dsh-subagent-tools and dsh-subagent-cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,8 @@ Management panel: Settings → Plugins.
 - [dsh-slice-agent-loop](https://github.com/dsh-external/dsh-slice-agent-loop) - Drop-in agent loop with bounded-slice context engine (cordis).
 - [savemoneybenchmark](https://github.com/dsh-external/savemoneybenchmark) - Cost-reduction benchmark (examples + skills).
 - [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) - MCP server exposing Harness agent: any MCP client (e.g. Hermes) drives Harness as its 'arms'.
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - Per-call model / provider / persona / toolFilter overrides for subagent delegation, @preset: references, provider/model composite ids (bundle, no patched files).
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - dsh-subagent-tools plus a per-call cwd for subagents, with the two in-process provider patches it requires.
 
 ## Git & Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -182,6 +182,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-slice-agent-loop](https://github.com/dsh-external/dsh-slice-agent-loop) - Drop-in agent loop：有界 slice 上下文引擎（cordis）
 - [savemoneybenchmark](https://github.com/dsh-external/savemoneybenchmark) - 降本增效 benchmark（examples + skills）
 - [dsh-harness-mcp-server](https://github.com/chushixixin/dsh-harness-mcp-server) - MCP server 暴露 Harness agent：任意 MCP 客户端（如 Hermes）驱动 Harness 当「胳膊」。
+- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - 子代理委派按次覆盖 model / provider / persona / toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）。
+- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - dsh-subagent-tools 加按次 cwd（子代理工作目录），附所需的两处进程内 provider 补丁。
 
 ## Git & Engineering
 


### PR DESCRIPTION
Add two subagent-delegation enhancement bundles to Models & Inference (EN + zh-CN):

- [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - per-call model/provider/persona/toolFilter overrides, @preset: references, provider/model composite ids (bundle, no patched official files)
- [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - the above plus per-call cwd for subagents, with the two in-process provider patches it requires

Both verified against stock dsh 0.1.0-rc.6 (headless + web).