### PR TITLE
docs: add dsh-web-billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Management panel: Settings → Plugins.
 
 ## UI & Experience
 
+- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - RMB/USD token billing for the DSH web: official-policy auto pricing (incl. peak/off-peak hours), per-message cost ledger, account balance, locale-driven currency display.
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek account balance and session cost in the DSH Web composer dock (auto-fetched official pricing, peak/off-peak support).
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - Live token estimates and generation TPS.
 - [dsh-view-modes](https://github.com/NigelYao/dsh-view-modes) - DSH Web output modes with Verbose, Normal, and Summary views, semantic grouping for tool calls and thinking, and live execution status.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## UI & Experience
 
+- [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - DSH Web 人民币/美元 token 计费插件：官方政策自动计价（含峰谷时段）、逐条消息费用账本、账号余额、按界面语言切换币种。
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek 账户余额与当前会话成本显示在 DSH Web 编辑器 dock 中（自动获取官方价格，支持峰时/非峰时计价）。
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - 实时 token 估算与生成 TPS
 - [dsh-view-modes](https://github.com/NigelYao/dsh-view-modes) - DSH Web 输出模式插件：提供详尽、普通和摘要视图，按语义分组工具调用与思考，并显示实时执行状态。


### PR DESCRIPTION
Add [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) to the UI & Experience section.

RMB/USD token-billing bundle for DSH web: official-policy auto pricing (curated policy schedule incl. the 2026-08-17 peak/off-peak rates), per-message cost ledger with reprice-on-restart, DeepSeek account balance, and locale-driven currency display. Public repo with the \dsh-plugin\ topic, MIT licensed.