### PR TITLE
docs: add dsh-science

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Infrastructure & Development](#infrastructure--development)
 - [Related](#related)
+- [Science & Research](#science--research)
 - [Thanks](#thanks)
 
 ## Install
@@ -254,6 +255,10 @@ Management panel: Settings → Plugins.
 - [dshp](https://github.com/asdf17128/dshp) - Profile manager: list, create, clone and diff profiles, and export a whole setup (bundle order, plugin versions, patch) as one portable file.
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data, open scoring model, rank/search/recommend tools and a settings-page leaderboard.
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading, and run compare/report.
+
+## Science & Research
+
+- [dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -44,6 +44,7 @@
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Infrastructure & Development](#infrastructure--development)
 - [Related](#related)
+- [Science & Research](#science--research)
 - [Thanks](#thanks)
 
 ## Install
@@ -252,6 +253,10 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dshp](https://github.com/asdf17128/dshp) - Profile 管理器：列出/新建/克隆/对比 profile，并把整套配置（bundle 顺序、插件版本、patch）导出为单个可移植文件。
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent 评测平台：benchmark YAML、headless dsh 运行、trace 指标、脚本化评分与 run 对比/报告。
+
+## Science & Research
+
+- [dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。
 
 ## Related
 


### PR DESCRIPTION
Add [dsh-science](https://github.com/biociao/dsh-science) under a new **Science & Research** category (EN `README.md` + `README.zh-CN.md`, incl. TOC).

Why a new category: this is a research-workbench plugin (ReAct research-loop engine, versioned artifacts with provenance, 10 science skills) — none of the existing categories (Core & Official / Context & Search / Input & Editing / UI & Experience / Browser & Remote / Models & Inference / Git & Engineering / Notifications & Channels / Fun & Lifestyle / Infrastructure & Development) covers it. Per contributing.md: "No matching category? Propose a new one in your PR."

Notes:
- Real, working code; declares `dsh.bundle` manifest (installable via `dsh plugin add`); `dsh-plugin` topic added.
- Smoke test 23/23 + isolated bundle install/boot verification pass.
- Happy to move the entry into an existing category instead if maintainers prefer.