### PR TITLE
docs: add @zhaoolee/dsh-notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Management panel: Settings → Plugins.
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat thumbnails (cordis).
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - Show actual command content instead of descriptions.
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - Official UI plugin reference implementation.
+- [@zhaoolee/dsh-notes](https://github.com/zhaoolee/notes) - Export DSH conversations as Smartisan Notes-style PNGs, or create and update Markdown notes in a configured account-scoped workspace.
 - [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) - Native Windows desktop shell: 1:1 official web UI with embedded server hosting, tray and auto-recovery.
 - [dsh-desktop](https://github.com/foolgry/dsh-desktop) - Download-and-run Electron desktop build (macOS/Windows installers): no Node.js or terminal needed, tracks upstream `@deepseek-ai/dsh` releases automatically, with built-in web UI and auto-update.
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - Right-side dot-timeline rail to jump between user messages.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,6 +164,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-chat-thumb](https://github.com/dsh-external/dsh-chat-thumb) - Chat 缩略图（cordis）
 - [show-bash-command](https://github.com/dsh-external/show-bash-command) - 显示命令具体内容而非描述
 - [turtle-ui](https://github.com/dsh-external/turtle-ui) - 官方 UI 插件参考实现
+- [@zhaoolee/dsh-notes](https://github.com/zhaoolee/notes) - 将 DSH 对话导出为锤子便签风格 PNG，或在配置的账号工作区中新建和更新 Markdown 便签。
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - 基于 pi-tui 的 DeepSeek Harness 终端前端：流式 Markdown、thinking 折叠、工具卡片、slash 命令、审批/提问交互与 Web 会话共享
 - [deepseek-harness-desktop](https://github.com/chyra-moon/deepseek-harness-desktop) - Windows 原生桌面外壳:一比一加载官方 Web UI,内置服务器托管、托盘驻留与掉线自动恢复
 - [dsh-desktop](https://github.com/foolgry/dsh-desktop) - 开箱即用的 Electron 桌面版（macOS/Windows 安装包）：无需 Node.js 和命令行，自动跟随上游 `@deepseek-ai/dsh` 发版，内置 Web UI 与自动更新


### PR DESCRIPTION
Closes #45

## What changed

- Added `@zhaoolee/dsh-notes` to **UI & Experience** in `README.md`.
- Added the matching Chinese entry to `README.zh-CN.md`.

## Why

`@zhaoolee/dsh-notes` gives DSH a conversation-export tool with two modes: Smartisan Notes-style PNG export through the public demo endpoint, or Markdown note creation and updates in a configured account-scoped notes workspace.

The source lives in the `dsh-plugin/` subpackage of `zhaoolee/notes`, is published on npm, declares `dsh.bundle.patch`, and the repository carries the `dsh-plugin` topic.

## Validation

- `git diff --check`
- Confirmed `@zhaoolee/dsh-notes@0.1.1` on npm
- `npm run test:dsh-plugin` in the source repository: 15/15 passing
