### PR TITLE
docs: add @picgo/dsh-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Management panel: Settings → Plugins.
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import Claude Code JSONL transcripts (tool history + thinking blocks) as resumable DeepSeek Harness sessions.
 - [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - Quick sticky notes in the composer: ideas/feelings/TODO with Markdown preview, auto-save, one-click send to chat.
 - [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) - Select text in a conversation, then quote it into the composer or reply in a new window.
+- [@picgo/dsh-plugin](https://github.com/PicGo/dsh-plugin) - Official PicGo plugin: upload local files to your image host and get public URLs, reusing the hosts and uploader plugins already configured in PicGo.
 
 - [dsh-suggested-replies](https://github.com/dsh-external/dsh-suggested-replies) - Suggested replies above the DSH Web composer. · [Input & Editing]
 ## UI & Experience

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -112,6 +112,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - 从 Claude Code JSONL 全保真导入历史会话（含工具调用/思考块），导入后可在 DSH 续聊
 - [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - 输入框工具栏快速便签：点子/感想/TODO，Markdown 预览、自动保存、一键发送到对话。
 - [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) - 在会话中划选文字，一键「引用回复」插入输入框，或「新窗口回复」开新会话并预填引用。
+- [@picgo/dsh-plugin](https://github.com/PicGo/dsh-plugin) - PicGo 官方插件：把本地文件传到图床拿到公网链接，复用你已在 PicGo 配好的图床与上传器插件。
 
 - [dsh-suggested-replies](https://github.com/dsh-external/dsh-suggested-replies) - DSH Web 输入框上方的预测回复插件。 · [Input & Editing]
 ## UI & Experience


### PR DESCRIPTION
Adds the official PicGo plugin for DeepSeek Harness to **Input & Editing**, in both language versions.

[`@picgo/dsh-plugin`](https://github.com/PicGo/dsh-plugin) lets the agent turn a local file into a public URL — the case that comes up whenever it writes a README, renders a chart, or captures a screenshot and the markdown image link would otherwise point at a path only you can see.

It uploads through whatever image host the user already configured in PicGo (PicGo Cloud, GitHub, S3, Tencent COS, Qiniu, …), including third-party PicGo uploader plugins, so there is nothing to re-configure. It registers a `picgo_upload` tool with structured output (usable directly in Code Mode), a `/picgo` command, and a bundled skill.

- npm: https://www.npmjs.com/package/@picgo/dsh-plugin
- Repo: https://github.com/PicGo/dsh-plugin (topic: `dsh-plugin`)

Markdown only — no other categories or files touched.