### PR TITLE
docs: update dsh-chat-import description (7 import sources)

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -1234,7 +1234,7 @@
 | [NexusAgentX/dsh-mcp-adapter](https://github.com/NexusAgentX/dsh-mcp-adapter) | MCP adapter for DeepSeek Harness — one proxy tool instead of dumping every MCP schema into context. |
 | [NinjaSln-labs/dsh-plugins](https://github.com/NinjaSln-labs/dsh-plugins) | DSH plugin collection: DeepSeek Harness community plugins (session-health, knowledge, ...) |
 | [NoWint/Oh-My-DSH](https://github.com/NoWint/Oh-My-DSH) | 🐋 DeepSeek Harness 插件精选集 · 300+ dsh-plugin 收录 · 22 大分类 |
-| [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从Claude Code、Codex、Reasonix等Agent工具导入历史消息，并在DSH中继续对话 |
+| [Nwflower/dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 从 Claude Code、Codex、ChatGPT、Cursor、Gemini、Reasonix、opencode 7 种 Agent 工具导入历史消息，并在 DSH 中继续对话 |
 | [Nwflower/dsh-file-claim](https://github.com/Nwflower/dsh-file-claim) | File claim / protection for concurrent DeepSeek Harness (DSH) sessions working the same workspace: claim/release, heartbeat stale takeover, async pending merge area (git 3-way merge). DSH Host plugin. |
 | [octoparse/agent-skills](https://github.com/octoparse/agent-skills) | Collection of Octoparse agent skills |
 | [omdsh-dev/dsh-book2skill](https://github.com/omdsh-dev/dsh-book2skill) | DSH book-to-skill plugin: a 5-stage long task (fetch → parse → understand → generate → install) with 3 human gates, host tools for the agent and a browser timeline panel |

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Management panel: Settings → Plugins.
 - [dsh-input-history](https://github.com/dsh-external/dsh-input-history) - Input history.
 - [dsh-multimedia-webui-input](https://github.com/dsh-external/dsh-multimedia-webui-input) - Multimedia file/folder input.
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Office file read/write bundle: model edits Office files, docx/pdf preview in web client.
-- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import Claude Code JSONL transcripts (tool history + thinking blocks) as resumable DeepSeek Harness sessions.
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - Import Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode transcripts (tool history + thinking blocks) as resumable DeepSeek Harness sessions.
 - [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - Quick sticky notes in the composer: ideas/feelings/TODO with Markdown preview, auto-save, one-click send to chat.
 - [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) - Select text in a conversation, then quote it into the composer or reply in a new window.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -109,7 +109,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-input-history](https://github.com/dsh-external/dsh-input-history) - 输入历史
 - [dsh-multimedia-webui-input](https://github.com/dsh-external/dsh-multimedia-webui-input) - 多媒体文件/文件夹输入
 - [dsh-office](https://github.com/dsh-external/dsh-office) - Office 文件读写 bundle：模型读写 Office 文件，docx/pdf 预览
-- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - 从 Claude Code JSONL 全保真导入历史会话（含工具调用/思考块），导入后可在 DSH 续聊
+- [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) - 从 Claude Code / Codex / ChatGPT / Cursor / Gemini / Reasonix / opencode 全保真导入历史会话（含工具调用/思考块），导入后可在 DSH 续聊
 - [dsh-sticky-note](https://github.com/Meredith2328/dsh-sticky-note) - 输入框工具栏快速便签：点子/感想/TODO，Markdown 预览、自动保存、一键发送到对话。
 - [dsh-plugin-quote-reply](https://github.com/yangYzc/dsh-plugin-quote-reply) - 在会话中划选文字，一键「引用回复」插入输入框，或「新窗口回复」开新会话并预填引用。
 


### PR DESCRIPTION
Update the `dsh-chat-import` description: the plugin now imports conversation histories from **7 sources** — Claude Code, Codex, ChatGPT, Cursor, Gemini, Reasonix, opencode — not just Claude Code. Changes are limited to the `dsh-chat-import` entry lines.