### PR TITLE
docs: add dsh-mcp-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Management panel: Settings → Plugins.
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data, open scoring model, rank/search/recommend tools and a settings-page leaderboard.
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading, and run compare/report.
 - [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) - Delete sessions from a running web runtime: live store, workspace records, and on-disk artifacts (no restart needed).
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors and reconnect counts via the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
 
 ## Science & Research
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -253,6 +253,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent 评测平台：benchmark YAML、headless dsh 运行、trace 指标、脚本化评分与 run 对比/报告。
 - [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) - 无需重启即可删除运行中 Web 运行时里的会话：实时存储、工作区记录与磁盘工件一并清理。
+- [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - 官方 MCP 客户端的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
 
 ## Science & Research
 


### PR DESCRIPTION
Adds [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) to **Infrastructure & Development** in both language versions (same entry, translated description).

- One-line summary: read-only runtime management panel for the official DeepSeek Harness MCP client — connection status, registered tools, errors, and reconnect counts via the `/mcp` command and a Settings tab, with sanitized display and enable/disable patch suggestions.
- Category rationale per `contributing.md`: "Infrastructure & Development — Registries, managers, catalogs, SDK tooling"; this plugin is a runtime management/observability tool for the official `dsh-mcp-client` (the sibling `dsh-mcp-manager` entry lives in the same category).
- Format follows the entry standard (`repository + one-line description + link`, no badges/blurbs); PR title follows the documented `docs: add <repo>` convention; alphabetical order is explicitly not required.
- The repo carries the `dsh-plugin` topic.
