### PR TITLE
Add dsh-meme-hub to Related

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Management panel: Settings → Plugins.
 ## Related
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue aggregation hub.
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual.
 - [DeepSeek](https://deepseek.com) - Official site.
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -262,6 +262,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Related
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue 聚合仓库
+- [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - 社区整活插件导航（皮肤/桌宠/小游戏），中英双语
 - [DeepSeek](https://deepseek.com) - 官方入口
 
 ## Contributing


### PR DESCRIPTION
加一个社区整活插件的导航站到 Related 区。

DSH 发布后头两天冒出来一批玩梗插件（贪玩蓝月式广告、QQ2006 皮肤、桌宠鲸鱼娘、18 款小游戏面板），这个仓库把它们整理成中英双语的分类导航，配了精选截图，方便新人找到这些项目的原仓库。纯导航，不分发代码。

两个 README（EN/ZH）的 Related 区各加一行。