### PR TITLE
docs: add dsh-git-branch-switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Management panel: Settings → Plugins.
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - Embedded task-management engine.
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - Incremental diff reviewer: checkpoint-based since-review queue with a Web UI panel, /review command, and feedback injection into the agent.
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect Vitest/Jest/pytest/node:test, run tests, parse failure summaries for the model.
+- [dsh-git-branch-switcher](https://github.com/mixin-ai/dsh-git-branch-switcher) - Session-header Git branch pill: shows the current workspace branch and switches branches from the Web UI.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,6 +196,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - 内嵌任务管理引擎
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - 增量代码审查插件：checkpoint 增量队列 + Web 审查面板 + /review 命令，审查意见注入 agent
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - 结构化测试运行工具（test_run）：自动识别 Vitest/Jest/pytest/node:test，运行测试并为模型解析失败摘要。
+- [dsh-git-branch-switcher](https://github.com/mixin-ai/dsh-git-branch-switcher) - 会话头部 Git 分支胶囊：显示当前项目分支，并可在 Web UI 中直接切换分支。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Add the **dsh-git-branch-switcher** plugin to the Git \& Engineering section (both README and README.zh-CN).

- Repo: https://github.com/mixin-ai/dsh-git-branch-switcher
- What it does: a session-header Git branch pill for the DSH Web UI — shows the current workspace branch and switches branches from the UI.
- Form: installable bundle (`dsh plugin --profile web add github:mixin-ai/dsh-git-branch-switcher#main`) with a Host Typert Remote service and a Web client bundle; tagged `dsh-plugin`.