### PR TITLE
Add dsh4vscode (VS Code client) under new IDE & Clients category

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ Management panel: Settings → Plugins.
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - Turn-index sidebar: one entry per user turn, click to jump, scroll-spy highlighting.
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count and whale-favicon recolor for sessions waiting for input or finished unopened.
 
+## IDE & Clients
+
+- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) - VS Code chat windows backed by the DSH agent: OpenCode-style independent sessions, model auto-routing (Flash/Pro/Pro Max).
+
 ## Browser & Remote
 
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - Headed browser embedded in the WebUI, model-driven (Codex-style, zero vision deps).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -156,6 +156,10 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - 轮次索引侧边栏：每条索引对应一轮用户提问，点击跳转并闪烁高亮，滚动时自动高亮当前轮次。
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - 关注提醒：会话等待输入或后台完成未打开时，左上角角标、标签页标题 (N) 计数与鲸鱼 favicon 换色三处联动。
 
+## IDE & Clients
+
+- [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) - 基于 DSH agent 的 VS Code 聊天窗口：OpenCode 式独立会话、模型自动路由（Flash/Pro/Pro Max）。
+
 ## Browser & Remote
 
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - WebUI 内嵌有头浏览器，模型实时操控（Codex 式，0 视觉依赖）


### PR DESCRIPTION
Adds [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) — a VS Code client that opens OpenCode-style chat windows backed by the DSH agent (independent sessions per window, model auto-routing Flash/Pro/Pro Max).

Both README.md and README.zh-CN.md updated in the same PR; proposes the new IDE & Clients category since the list has no matching category yet. The repository already carries the dsh-plugin topic.