### PR TITLE
docs: add dsh-doublecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Management panel: Settings → Plugins.
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - Embedded task-management engine.
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - Incremental diff reviewer: checkpoint-based since-review queue with a Web UI panel, /review command, and feedback injection into the agent.
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect Vitest/Jest/pytest/node:test, run tests, parse failure summaries for the model.
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates, and an adversarial delivery review.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -196,6 +196,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - 内嵌任务管理引擎
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - 增量代码审查插件：checkpoint 增量队列 + Web 审查面板 + /review 命令，审查意见注入 agent
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - 结构化测试运行工具（test_run）：自动识别 Vitest/Jest/pytest/node:test，运行测试并为模型解析失败摘要。
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - 工程纪律闭环：动工前盘问需求、红绿测试证据门、交付前对抗式审查。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Adds `dsh-doublecheck` under **Git & Engineering** in both `README.md` (English) and `README.zh-CN.md` (简体中文), per `contributing.md` (same entry in both language versions, one-line factual description).

- Repo: https://github.com/PerryLink/dsh-doublecheck
- One-liner: Double-check before you ship: grill the requirements, test the implementation, prove the delivery.
- The repo carries the `dsh-plugin` topic.
- Category fit: engineering workflow / discipline loop (requirement grilling before edits, red/green test-evidence gates, adversarial delivery review) — alongside the existing `dsh-inspect` and `dsh-review-loop` entries in this category.
