### PR TITLE
docs: add dsh-doublecheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ Management panel: Settings → Plugins.
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - Embedded task-management engine.
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - Incremental diff reviewer: checkpoint-based since-review queue with a Web UI panel, /review command, and feedback injection into the agent.
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect Vitest/Jest/pytest/node:test, run tests, parse failure summaries for the model.
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - Engineering-discipline bundle: grill the requirements, test the implementation, prove the delivery.
 - [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates, and an adversarial delivery review.
 
 ## Notifications & Channels

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -202,6 +202,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-involute](https://github.com/dsh-external/dsh-involute) - 内嵌任务管理引擎
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - 增量代码审查插件：checkpoint 增量队列 + Web 审查面板 + /review 命令，审查意见注入 agent
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - 结构化测试运行工具（test_run）：自动识别 Vitest/Jest/pytest/node:test，运行测试并为模型解析失败摘要。
+- [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - 工程纪律包：交付前三查——查需求、查实现、查证据。
 - [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - 工程纪律闭环：动工前盘问需求、红绿测试证据门、交付前对抗式审查。
 
 ## Notifications & Channels


### PR DESCRIPTION
`docs: add dsh-doublecheck` - title and content follow contributing.md (title convention, entry standard, both language files in the same PR).

- **Category**: **Git & Engineering** (contributing.md: "Git identity, workflows, plugin health") - the plugin is an engineering-discipline/workflow bundle: grill the requirements, test the implementation, prove the delivery.
- **Repo**: https://github.com/PerryLink/dsh-doublecheck (public; carries the `dsh-plugin` topic, verified via GitHub API: `deepseek-harness,dsh,dsh-plugin`)
- **Entry standard**: real repository + one-line factual description + link; no badges/screenshots/blurbs (contributing.md "Entry standard")
- **Both language versions in the same PR**: `README.md` (EN) and `README.zh-CN.md` (ZH, translated description) - per contributing.md "Where to add"
- **Load-level evidence (real run, not fabricated)**: on a real DSH install, `dsh --profile headless --dump-config` shows both bundle rows (`doublecheck-grill`, `doublecheck-guard`) in the composed tree, and `dsh --profile headless "hi"` completes with exit 0. Note: installing via `dsh plugin --profile <name> add https://github.com/PerryLink/dsh-doublecheck` requires a pnpm `allowBuilds` entry (git-hosted prepare script).