### PR TITLE
docs: add dsh-memento

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Management panel: Settings → Plugins.
 - [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) - Context management: context saving and more (cordis).
 - [dsh-kb-sieve](https://github.com/dsh-external/dsh-kb-sieve) - Knowledge-base plugin: build auditable KB packages (references + SQL).
 - [dsh-payload-capture](https://github.com/moeblack/dsh-payload-capture) - Capture every upstream model API payload to JSON (debug & observability).
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) - Bounded, layered, approval-gated, auditable cross-session memory: typed ctx.memory seam, zero-dependency SQLite provider, memory tool and frozen snapshot injection.
 
 ## Input & Editing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -100,6 +100,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-easy-ctx-manager](https://github.com/dsh-external/dsh-easy-ctx-manager) - 上下文管理：上下文节省等（cordis）
 - [dsh-kb-sieve](https://github.com/dsh-external/dsh-kb-sieve) - knowledge-base 插件：构建可审计 KB 包（references + SQL）
 - [dsh-payload-capture](https://github.com/moeblack/dsh-payload-capture) - 捕捉每一次上行模型 API payload 存为 JSON（调试与观测）
+- [dsh-memento](https://github.com/PerryLink/dsh-memento) - 有界、分层、带审批门、可审计的跨会话记忆：ctx.memory 服务、零依赖 SQLite、memory 工具与冻结快照注入。
 
 ## Input & Editing
 


### PR DESCRIPTION
Adds **dsh-memento** to the `Context & Search` category in both `README.md` and `README.zh-CN.md`, as required by `contributing.md` ("Both language versions should be updated in the same PR — same entry, translated description").

- **Entry**: [dsh-memento](https://github.com/PerryLink/dsh-memento) — bounded, layered, approval-gated, auditable cross-session memory: typed `ctx.memory` seam, zero-dependency SQLite provider, `memory` tool and frozen snapshot injection.
- **Category basis**: `contributing.md` maps `Context & Search` to "Session search, memory, knowledge retrieval" — the plugin is a cross-session memory capability (siblings dsh-memoria / dsh-memory-evolve / dsh-mnemon live in this category). `Git & Engineering` (git identity, workflows, plugin health) does not match the plugin's purpose.
- **Format basis**: `contributing.md` "Entry standard" — real repository, one-line factual description, link; no badges/screenshots/blurbs per entry.
- The repo carries the [`dsh-plugin`](https://github.com/topics/dsh-plugin) topic for public discovery.
