### PR TITLE
docs: add dsh-plugin-description

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Management panel: Settings → Plugins.
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - Right-side dot-timeline rail to jump between user messages.
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - Turn-index sidebar: one entry per user turn, click to jump, scroll-spy highlighting.
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count and whale-favicon recolor for sessions waiting for input or finished unopened.
-- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - Adds bilingual (zh/en) descriptions to every plugin card on the Web Settings plugin list; publishes a pluginDescriptions service for other plugins to register their own.
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - Adds bilingual (zh/en) descriptions to every plugin card on the Web Settings plugin list; publishes a `pluginDescriptions` service for other plugins to register their own.
 
 ## IDE & Clients
 

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Management panel: Settings → Plugins.
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - Right-side dot-timeline rail to jump between user messages.
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - Turn-index sidebar: one entry per user turn, click to jump, scroll-spy highlighting.
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count and whale-favicon recolor for sessions waiting for input or finished unopened.
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - Adds bilingual (zh/en) descriptions to every plugin card on the Web Settings plugin list; publishes a pluginDescriptions service for other plugins to register their own.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,6 +157,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - 右侧圆点时间轴导航栏，快速跳转到任意用户消息。
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - 轮次索引侧边栏：每条索引对应一轮用户提问，点击跳转并闪烁高亮，滚动时自动高亮当前轮次。
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - 关注提醒：会话等待输入或后台完成未打开时，左上角角标、标签页标题 (N) 计数与鲸鱼 favicon 换色三处联动。
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - 为 Web 设置插件列表页的每张插件卡片补上中英文功能说明，并提供 pluginDescriptions 服务供其他插件注册自己的说明。
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -157,7 +157,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-milestone](https://github.com/SnowCrescenter-tech/dsh-milestone) - 右侧圆点时间轴导航栏，快速跳转到任意用户消息。
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - 轮次索引侧边栏：每条索引对应一轮用户提问，点击跳转并闪烁高亮，滚动时自动高亮当前轮次。
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - 关注提醒：会话等待输入或后台完成未打开时，左上角角标、标签页标题 (N) 计数与鲸鱼 favicon 换色三处联动。
-- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - 为 Web 设置插件列表页的每张插件卡片补上中英文功能说明，并提供 pluginDescriptions 服务供其他插件注册自己的说明。
+- [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - 为 Web 设置插件列表页的每张插件卡片补上中英文功能说明，并提供 `pluginDescriptions` 服务供其他插件注册自己的说明。
 
 ## IDE & Clients
 


### PR DESCRIPTION
## 收录申请

申请在 **UI & Experience** 分类收录 [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description)。

**功能**：在 Web 设置的「插件列表」页为每张插件卡片补上中英文功能说明，并发布 `pluginDescriptions` 服务，供其他插件注册/覆盖自己的说明。内置覆盖 DSH 官方插件全部 134 个模块名的双语字典，用户可在页面直接编辑说明并持久化到 `<DSH_HOME>/plugin-descriptions.json`。

**条目**：

- 英文：`Adds bilingual (zh/en) descriptions to every plugin card on the Web Settings plugin list; publishes a pluginDescriptions service for other plugins to register their own.`
- 中文：`为 Web 设置插件列表页的每张插件卡片补上中英文功能说明，并提供 pluginDescriptions 服务供其他插件注册自己的说明。`

**检查清单**：真实公开仓库 ✓ / 一句话描述 ✓ / 仓库链接 ✓ / 双语同步 ✓ / 标题遵循 `docs: add <repo>` ✓