### PR TITLE
docs: add ciceroyang/dsh-report-studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@
 - [Browser & Remote](#browser--remote)
 - [Models & Inference](#models--inference)
 - [Git & Engineering](#git--engineering)
+- [Output & Deliverables](#output--deliverables)
 - [Notifications & Channels](#notifications--channels)
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Infrastructure & Development](#infrastructure--development)
@@ -205,6 +206,10 @@ Management panel: Settings → Plugins.
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - Incremental diff reviewer: checkpoint-based since-review queue with a Web UI panel, /review command, and feedback injection into the agent.
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - Structured test runner tool (test_run): auto-detect Vitest/Jest/pytest/node:test, run tests, parse failure summaries for the model.
 - [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - Engineering-discipline loop: requirement grilling before edits, red/green test-evidence gates, and an adversarial delivery review.
+
+## Output & Deliverables
+
+- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - Turn a DeepSeek Harness session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,7 +41,7 @@
 - [Browser & Remote](#browser--remote)
 - [Models & Inference](#models--inference)
 - [Git & Engineering](#git--engineering)
-- [输出与交付](#输出与交付)
+- [Output & Deliverables](#output--deliverables)
 - [Notifications & Channels](#notifications--channels)
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Infrastructure & Development](#infrastructure--development)
@@ -205,7 +205,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - 结构化测试运行工具（test_run）：自动识别 Vitest/Jest/pytest/node:test，运行测试并为模型解析失败摘要。
 - [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - 工程纪律闭环：动工前盘问需求、红绿测试证据门、交付前对抗式审查。
 
-## 输出与交付
+## Output & Deliverables
 
 - [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - 把 DeepSeek Harness 会话一键变成工作日报/周报/交接文档/公众号文章，附可验证凭据（报告与产物哈希）。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,6 +41,7 @@
 - [Browser & Remote](#browser--remote)
 - [Models & Inference](#models--inference)
 - [Git & Engineering](#git--engineering)
+- [输出与交付](#输出与交付)
 - [Notifications & Channels](#notifications--channels)
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Infrastructure & Development](#infrastructure--development)
@@ -203,6 +204,10 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-review-loop](https://github.com/wuxiangru915/dsh-review-loop) - 增量代码审查插件：checkpoint 增量队列 + Web 审查面板 + /review 命令，审查意见注入 agent
 - [dsh-test-runner](https://github.com/suimi8/dsh-test-runner) - 结构化测试运行工具（test_run）：自动识别 Vitest/Jest/pytest/node:test，运行测试并为模型解析失败摘要。
 - [dsh-doublecheck](https://github.com/PerryLink/dsh-doublecheck) - 工程纪律闭环：动工前盘问需求、红绿测试证据门、交付前对抗式审查。
+
+## 输出与交付
+
+- [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - 把 DeepSeek Harness 会话一键变成工作日报/周报/交接文档/公众号文章，附可验证凭据（报告与产物哈希）。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Adds dsh-report-studio and proposes a new curated category **Output & Deliverables** (输出与交付).

dsh-report-studio turns a DeepSeek Harness session into deliverable work reports (daily / weekly / handoff / WeChat article) with verifiable receipts (report + artifact SHA-256). No existing category fits session-to-document deliverables; the new category also gives future export/share-adjacent plugins a home.

- Repo: https://github.com/ciceroyang/dsh-report-studio
- Topic: dsh-plugin
- Tests: 22/22 (node:test)
- Verified end-to-end on a real Harness session