### PR TITLE
fix: point dsh-island to public repository

### DIFF
--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -41,6 +41,7 @@ NAME_REWRITES = {
 }
 URL_REWRITES = {
     "context-doctor": "https://github.com/Zhenyu98/dsh-context-doctor",
+    "dsh-island": "https://github.com/ChuanTianML/dsh-island",
 }
 
 # ===== Manual topic categories (curated 2026-08-14; applied before keyword fallback) =====


### PR DESCRIPTION
The generated catalog currently keeps the private Hub dsh-island URL and adds the public Topic repository as a second entry. Rewrite the Hub URL to the current public repository before URL deduplication so the next catalog sync produces one usable entry.\n\nValidation: imported the generator, verified url_for returns the public repository, simulated the hub/topic dedup key, and ran git diff --check.