### PR TITLE
docs: add Han-1413141/dsh-cost-meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Management panel: Settings → Plugins.
 - [dsh-ultra-ui](https://github.com/dsh-external/dsh-ultra-ui) - Ultra UI plugin (cordis).
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - RMB/USD token billing for the DSH web: official-policy auto pricing (incl. peak/off-peak hours), per-message cost ledger, account balance, locale-driven currency display.
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek account balance and session cost in the DSH Web composer dock (auto-fetched official pricing, peak/off-peak support).
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - Per-session and daily API cost, budget with usage %, official balance, history dashboard, and one-click official price sync with peak/off-peak pricing.
 - [dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost) - Session cost estimate in the DSH Web composer dock (tokenUsage × configurable price table, one-click official-price refresh).
 - [dsh-spend](https://github.com/nonewind/dsh-spend) - Token usage and estimated spend for the DSH web UI: floating panel with per-model / per-day / per-session stats and auto-detected billing plans.
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - Live token estimates and generation TPS.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -135,6 +135,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-ultra-ui](https://github.com/dsh-external/dsh-ultra-ui) - ultra-ui 插件（cordis）。
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - DSH Web 人民币/美元 token 计费插件：官方政策自动计价（含峰谷时段）、逐条消息费用账本、账号余额、按界面语言切换币种。
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek 账户余额与当前会话成本显示在 DSH Web 编辑器 dock 中（自动获取官方价格，支持峰时/非峰时计价）。
+- [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) - 会话与当日 API 费用统计、预算图框（已用%）、官方余额、历史看板，支持峰谷计价与官方价格一键同步。
 - [dsh-plugin-cost](https://github.com/yweilai77-dev/dsh-plugin-cost) - DSH Web 聊天框底部的会话费用估算：token 四桶 × 可配置价格表，一键刷新官方价格（估算非账单）。
 - [dsh-spend](https://github.com/nonewind/dsh-spend) - DSH Web 用量与预计费用统计：右下角悬浮窗，按模型/按天/按会话多维聚合，内置供应商知识库自动识别计费计划。
 - [dsh-live-stats](https://github.com/dsh-external/dsh-live-stats) - 实时 token 估算与生成 TPS


### PR DESCRIPTION
Add **dsh-cost-meter** ([repo](https://github.com/Han-1413141/dsh-cost-meter)) — a session-cost / usage-metering plugin for the DeepSeek Harness Web GUI.

What it does:

- Per-session cost badge in the composer dock or session header, with input / cache / output token breakdown
- Daily cost + official account balance (total / granted / topped-up) in the sidebar
- Budget box with usage %, progress bar and over-budget warnings (today / month / total / custom range)
- Settings dashboard: summary cards, per-session breakdown, day-level history (retention configurable)
- DeepSeek peak/off-peak pricing with effective-time gating and current-tier indicator
- One-click official price sync (parses the official pricing page), manual editing as fallback

Repo is public, non-fork, MIT-licensed, and carries the `dsh-plugin` topic.
Install: `dsh plugin --profile web add github:Han-1413141/dsh-cost-meter`
Screenshots: https://github.com/Han-1413141/dsh-cost-meter#图文演示
Entry added under *UI & Experience* in both README.md and README.zh-CN.md (same PR, as requested in the contribution guide).