### PR TITLE
docs: add dsh-builtin-toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Management panel: Settings → Plugins.
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - Turn-index sidebar: one entry per user turn, click to jump, scroll-spy highlighting.
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - Attention reminders: frame badge, tab-title count and whale-favicon recolor for sessions waiting for input or finished unopened.
 - [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - Adds bilingual (zh/en) descriptions to every plugin card on the Web Settings plugin list; publishes a `pluginDescriptions` service for other plugins to register their own.
+- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Human-readable catalog for official DSH Web built-ins with status explanations and an audited set of safe UI toggles.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -168,6 +168,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-turn-index](https://github.com/Simon314620/dsh-turn-index) - 轮次索引侧边栏：每条索引对应一轮用户提问，点击跳转并闪烁高亮，滚动时自动高亮当前轮次。
 - [dsh-web-attention-badge](https://github.com/Luaphes/dsh-web-attention-badge) - 关注提醒：会话等待输入或后台完成未打开时，左上角角标、标签页标题 (N) 计数与鲸鱼 favicon 换色三处联动。
 - [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - 为 Web 设置插件列表页的每张插件卡片补上中英文功能说明，并提供 `pluginDescriptions` 服务供其他插件注册自己的说明。
+- [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - DSH Web 官方内置插件的人类可读目录，提供状态解释与经过审核的安全 UI 开关。
 
 ## IDE & Clients
 


### PR DESCRIPTION
Adds `dsh-builtin-toggles` to the UI & Experience section in both English and Chinese.

A community plugin published to npm (`dsh-builtin-toggles@0.2.0`) that declares `dsh.bundle` in its package.json and is installable via `dsh plugin add`.

Repository: https://github.com/Starfie1d1272/dsh-builtin-toggles
