### PR TITLE
docs: add dsh-session-cleaner-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,6 +286,7 @@ Management panel: Settings → Plugins.
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data, open scoring model, rank/search/recommend tools and a settings-page leaderboard.
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading, and run compare/report.
 - [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) - Delete sessions from a running web runtime: live store, workspace records, and on-disk artifacts (no restart needed).
+- [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) - Offline CLI that deep-cleans workspace sessions: interactive/batch delete with trash + restore + backups, workspace-registry and projection-cache sync, ghost-entry pruning. Companion to the runtime delete plugin.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors and reconnect counts via the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
 
 ## Science & Research

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -284,6 +284,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent 评测平台：benchmark YAML、headless dsh 运行、trace 指标、脚本化评分与 run 对比/报告。
 - [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) - 无需重启即可删除运行中 Web 运行时里的会话：实时存储、工作区记录与磁盘工件一并清理。
+- [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) - 工作区会话离线深度清理 CLI：交互/批量删除（回收站+恢复+自动备份）、工作区账目与投影缓存同步、幽灵条目修剪，与运行时删除插件互补。
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - 官方 MCP 客户端的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
 
 ## Science & Research


### PR DESCRIPTION
Add **dsh-session-cleaner-cli** — an offline CLI companion that deep-cleans DeepSeek Harness workspace sessions: interactive/batch delete with a trash bin + restore + automatic backups, workspace-registry (`storages/workspace.json`) and projection-cache sync, ghost-entry pruning, a running-server guard, cross-instance mutex lock, and cross-platform support (Windows / macOS / Linux). Zero runtime dependencies, Node ≥ 18, 13 end-to-end tests, GitHub Actions CI on ubuntu / macos / windows × Node 18/20/24.

- Repo: https://github.com/ChenChen913/dsh-session-cleaner-cli
- Tagged `dsh-plugin` (listed on the topic page); bilingual README (Chinese default + English).
- Placed next to the fountunt/dsh-session-cleaner runtime plugin entry in **Infrastructure & Development**; both English and Chinese versions updated in this PR.

Verified against deepseek-harness mainline `47f9438` (2026-08-13).
