### PR TITLE
docs: add dsh-plugin-vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ Management panel: Settings → Plugins.
 ## Models & Inference
 
 - [dsh-vision](https://github.com/dsh-external/dsh-vision) - Vision bridge: view_image tool over any OpenAI-compatible VLM (Zhipu free tier by default).
+- [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision) - Vision for text-only LLMs: image description / OCR / VQA via free Gemini and GLM vision APIs.
 - [dsh-advisor](https://github.com/dsh-external/dsh-advisor) - Second model passively reviews each turn and injects notes.
 - [dsh-llm-fallbacks](https://github.com/dsh-external/dsh-llm-fallbacks) - Role-based LLM retry/fallback strategy.
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - ExtensionAPI bridge for pi.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,6 +187,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Models & Inference
 
 - [dsh-vision](https://github.com/dsh-external/dsh-vision) - 视觉桥接：view_image 工具接任意 OpenAI 兼容 VLM（默认智谱免费档）
+- [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision) - 为纯文本大模型提供视觉能力：通过免费的 Gemini / GLM 视觉 API 完成图像描述、OCR 与视觉问答
 - [dsh-advisor](https://github.com/dsh-external/dsh-advisor) - 副模型每轮被动审查并注入建议
 - [dsh-llm-fallbacks](https://github.com/dsh-external/dsh-llm-fallbacks) - 角色化 LLM 重试/备用策略
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - pi ExtensionAPI 桥接


### PR DESCRIPTION
## What

Add [dsh-plugin-vision](https://github.com/tdf1995/dsh-plugin-vision) to the **Models & Inference** category.

## Why

`dsh-plugin-vision` gives text-only LLMs (e.g. DeepSeek) vision capabilities - image description / OCR / VQA - through the free Gemini (`gemini-3.6-flash`) and Zhipu GLM (`glm-4.6v-flash`) vision APIs. Key features: dual-provider auto failover, rate-limit retry, large-image downscaling, and an optional browser paste-and-drop companion (dynamic plugin).

## Checklist

- [x] Real repository, no dead links / placeholders
- [x] One-line factual description (English + Chinese)
- [x] Both `README.md` and `README.zh-CN.md` updated in the same PR
- [x] Markdown only, no tests