### PR TITLE
Add dsh-adb: ADB device & bench operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Management panel: Settings → Plugins.
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) - Offline CLI that deep-cleans workspace sessions: interactive/batch delete with trash + restore + backups, workspace-registry and projection-cache sync, ghost-entry pruning. Companion to the runtime delete plugin.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors and reconnect counts via the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
 
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB device & bench operations: device discovery, structured logcat (background streaming), apk install, file pull/push, dumpsys performance snapshots.
+
 ## Science & Research
 
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - Generate interactive OpenMAIC AI classrooms.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -298,6 +298,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) - 工作区会话离线深度清理 CLI：交互/批量删除（回收站+恢复+自动备份）、工作区账目与投影缓存同步、幽灵条目修剪，与运行时删除插件互补。
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - 官方 MCP 客户端的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
 
+- [dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB 设备与台架运维：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照
+
 ## Science & Research
 
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - 生成 OpenMAIC 交互式 AI 课堂。


### PR DESCRIPTION
Adds [dsh-adb](https://github.com/SamXiaBing/dsh-adb) to the Infrastructure & Development category.

dsh-adb gives DSH agents direct ADB device & bench operations: device discovery, structured logcat with background streaming (jobs), apk install, file pull/push, and dumpsys performance snapshots (meminfo/gfxinfo/battery). Built for automotive cockpit / bench workflows but applicable to any Android device.

Both README.md and README.zh-CN.md updated.