### PR TITLE
docs: add dsh-passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,7 @@ Management panel: Settings → Plugins.
 - [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) - Delete sessions from a running web runtime: live store, workspace records, and on-disk artifacts (no restart needed).
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) - Offline CLI that deep-cleans workspace sessions: interactive/batch delete with trash + restore + backups, workspace-registry and projection-cache sync, ghost-entry pruning. Companion to the runtime delete plugin.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors and reconnect counts via the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - Login gateway for the DSH web UI: first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF and anti-framing headers.
 
 ## Science & Research
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -297,6 +297,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-session-cleaner](https://github.com/fountunt/dsh-session-cleaner) - 无需重启即可删除运行中 Web 运行时里的会话：实时存储、工作区记录与磁盘工件一并清理。
 - [dsh-session-cleaner-cli](https://github.com/ChenChen913/dsh-session-cleaner-cli) - 工作区会话离线深度清理 CLI：交互/批量删除（回收站+恢复+自动备份）、工作区账目与投影缓存同步、幽灵条目修剪，与运行时删除插件互补。
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - 官方 MCP 客户端的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
+- [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防暴力破解、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。
 
 ## Science & Research
 


### PR DESCRIPTION
Adds [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) to the Infrastructure & Development section.

What it is: an independent login gateway (password door) in front of the DSH web UI — first-run setup with install key, bcrypt password hashing, at-rest encryption of user data (AES-256-GCM + HMAC lookups), brute-force lockout, audit log, HTTPS (TLS 1.2+, HSTS, 80→443 redirect), CSRF protection, anti-framing headers, and theme-following login page. BSD-3-Clause.

The repo carries the `dsh-plugin` topic.