### PR TITLE
docs: add dsh-file-mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-description](https://github.com/MysaDC/dsh-plugin-description) - Adds bilingual (zh/en) descriptions to every plugin card on the Web Settings plugin list; publishes a `pluginDescriptions` service for other plugins to register their own.
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Human-readable catalog for official DSH Web built-ins with status explanations and an audited set of safe UI toggles.
 - [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel.
+- [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - Clickable file paths in DSH replies: Codex-style inline open, 📂 reveal in file manager, and a mentioned-files chip list at the turn tail.
 
 ## IDE & Clients
 


### PR DESCRIPTION
Add [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) to the UI & Experience section: clickable file paths in DSH replies (Codex-style inline open, reveal in file manager, mentioned-files chip list). Zero-dependency, bundle-installable.