### PR TITLE
docs: add dsh-lan-access

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Management panel: Settings → Plugins.
 - [dsh-deeplink](https://github.com/dsh-external/dsh-deeplink) - Open DSH WebUI sessions or workspaces directly from URL parameters.
 - [dsh-remote](https://github.com/dsh-external/dsh-remote) - SSH remote control.
 - [dsh-remote](https://github.com/flymysql/dsh-remote) - Remote-access assistant: prints the exact SSH local-forward / autossh / reverse-tunnel / reverse-proxy commands for the live instance (the web GUI binds loopback only).
+- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) - LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts (npm: dsh-lan-access).
 - [ego-browser](https://github.com/dsh-external/ego-browser) - Browser agent.
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web bridge.
 - [browser4-dsh](https://github.com/dsh-external/browser4-dsh) - Browser4 AI-native browser engine (skills).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -193,6 +193,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-deeplink](https://github.com/dsh-external/dsh-deeplink) - 通过 URL 参数直接打开 DSH WebUI 会话或工作区。
 - [dsh-remote](https://github.com/dsh-external/dsh-remote) - SSH 远端控制
 - [dsh-remote](https://github.com/flymysql/dsh-remote) - 远程访问助手：为当前实例打印精确的 SSH 本地转发 / autossh 保活 / 反向隧道 / 反向代理命令（Web GUI 仅绑定回环地址）。
+- [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) - 局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃），npm 可装
 - [ego-browser](https://github.com/dsh-external/ego-browser) - 浏览器代理
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web 桥接
 - [browser4-dsh](https://github.com/dsh-external/browser4-dsh) - Browser4 AI-native 浏览器引擎（skills）


### PR DESCRIPTION
Add [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) to the Browser & Remote category: LAN access for the DSH Web GUI — 0.0.0.0 bind + crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts. Published on npm as `dsh-lan-access`.