### PR TITLE
docs: add easyeda-agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ Management panel: Settings → Plugins.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - Read-only runtime management panel for the official DSH MCP client: connection status, registered tools, errors and reconnect counts via the /mcp command and a Settings tab, with sanitized display and enable/disable patch suggestions.
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - Login gateway for the DSH web UI: first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF and anti-framing headers.
 
+- [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) - EasyEDA Pro automation: Go daemon + in-app connector + agent skill + stdio MCP server for typed schematic/PCB actions, workflow gates, and DRC.
 - [dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB device & bench operations: device discovery, structured logcat (background streaming), apk install, file pull/push, dumpsys performance snapshots.
 - [dsh-restart](https://github.com/anweat/dsh-restart) - Restart DSH: configurable restart method (Node native / legacy PowerShell), post-restart continue prompt, optional watchdog auto-relaunch.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -310,6 +310,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - 官方 MCP 客户端的只读运行时管理面板：/mcp 命令与设置页 MCP 页签展示连接状态、已注册工具、错误与重连计数，脱敏展示并提供启停 patch 建议。
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防暴力破解、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。
 
+- [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) - 嘉立创EDA专业版(EasyEDA Pro)自动化：Go daemon + 编辑器内连接器 + agent skill + stdio MCP server，typed 原理图/PCB 动作、流程门禁与 DRC。
 - [dsh-adb](https://github.com/SamXiaBing/dsh-adb) - ADB 设备与台架运维：设备发现、结构化 logcat（后台采集）、apk 安装、文件 pull/push、性能快照
 - [dsh-restart](https://github.com/anweat/dsh-restart) - DSH 重启插件：可配置的重启方式（Node 原生/旧 PowerShell 适配）、重启后自动继续的提示词、可选看门狗自动拉起。
 


### PR DESCRIPTION
Add [easyeda-agent](https://github.com/zhoushoujianwork/easyeda-agent) to **Infrastructure & Development** (next to dsh-adb).

**What it is:** EasyEDA Pro (嘉立创EDA专业版) automation — a Go CLI/daemon + in-app connector + agent skill (`SKILL.md`) + stdio MCP server (11 tools). It drives typed schematic/PCB actions through the official `eda.*` API with workflow gates, autosave, audit log, and DRC. The `dsh-plugin` topic is already set on the repo, so it will also surface in the public topic catalog.

**Why this category:** same shape as dsh-adb — a bridge to an external hardware/toolchain (EasyEDA Pro) rather than a DSH-internal utility.

Both EN and ZH entries updated.