### PR TITLE
add dsh-auto-continue to UI & Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Management panel: Settings → Plugins.
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - Human-readable catalog for official DSH Web built-ins with status explanations and an audited set of safe UI toggles.
 - [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD status panel: git status, MCP servers, skills, model and token usage in a floating side panel.
 - [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - Clickable file paths in DSH replies: Codex-style inline open, 📂 reveal in file manager, and a mentioned-files chip list at the turn tail.
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - Auto-resumes interrupted DSH Web requests: sends a queued 「继续」 after network/timeout/host-crash failures, with error classification, adaptive backoff, templated continue text and browser notifications; everything configurable from the plugin settings card.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -183,6 +183,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-builtin-toggles](https://github.com/Starfie1d1272/dsh-builtin-toggles) - DSH Web 官方内置插件的人类可读目录，提供状态解释与经过审核的安全 UI 开关。
 - [dsh-hud](https://github.com/a903067276-rgb/dsh-hud) - HUD 状态面板：Git 状态、MCP 服务器、技能列表、模型与 token 用量，悬浮侧栏一览无余。
 - [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - 回复中的可点击文件路径：Codex 风格内联打开、📂 文件管理器显示、回合末尾的文件提及 chip 列表。
+- [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - DSH Web 请求中断自动续跑：网络/超时/宿主崩溃等非人为失败后自动发送「继续」，支持错误分类、自适应退避、模板化继续文本与浏览器通知；全部参数可在插件设置卡片中调整。
 
 ## IDE & Clients
 


### PR DESCRIPTION
## What

Add [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) to **UI & Experience** (both `README.md` and `README.zh-CN.md`).

## Why

A DSH Web plugin that auto-resumes interrupted requests: after network/timeout/host-crash failures it sends a queued 「继续」, with error classification (permanent auth/balance/model errors are skipped), adaptive backoff, templated continue text (`{code}` `{tool}` …) and optional browser notifications. All knobs live in the plugin settings card. Published on npm (`dsh-client-auto-continue`, v0.3.0), `dsh-plugin` topic set, 12 headless behavioral tests green.

## Checklist

- [x] Real public repository (dead-link free)
- [x] One-line factual description in both language versions
- [x] Category: UI & Experience
