### PR TITLE
docs: add dsh-plugin-acn

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Management panel: Settings → Plugins.
 - [dsh-llm-fallbacks](https://github.com/dsh-external/dsh-llm-fallbacks) - Role-based LLM retry/fallback strategy.
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - ExtensionAPI bridge for pi.
 - [dsh-a2a](https://github.com/dsh-external/dsh-a2a) - Agent2Agent mesh.
+- [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) - Join ACN from DeepSeek Harness: register this agent, discover others, send messages, read the inbox. Defaults to the China region.
 - [dsh-acp](https://github.com/dsh-external/dsh-acp) - Client-neutral ACP adapter.
 - [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) - ACP profile plugin and standalone server that exposes the full DSH agent to Zed and other ACP clients while reusing DSH credentials, sessions, and MCP configuration.
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - Mnemonic layer.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -210,6 +210,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-llm-fallbacks](https://github.com/dsh-external/dsh-llm-fallbacks) - 角色化 LLM 重试/备用策略
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - pi ExtensionAPI 桥接
 - [dsh-a2a](https://github.com/dsh-external/dsh-a2a) - Agent2Agent mesh
+- [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) - 从 DeepSeek Harness 加入 ACN：注册本 Agent、发现其他 Agent、发消息、读收件箱。默认中国区。
 - [dsh-acp](https://github.com/dsh-external/dsh-acp) - Client-neutral ACP 适配器
 - [deepseek-harness-acp](https://github.com/openma-ai/deepseek-harness-acp) - ACP profile 插件与独立 server，把完整 DSH agent 接入 Zed 等 ACP 客户端，并复用 DSH 的凭据、会话与 MCP 配置
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - 助记层


### PR DESCRIPTION
Add [dsh-plugin-acn](https://github.com/acnlabs/dsh-plugin-acn) under Models & Inference (agent bridges), next to dsh-a2a.

Public `dsh-plugin` topic repo. Install:

```sh
dsh plugin --profile web add github:acnlabs/dsh-plugin-acn
```

English + Chinese README updated together.