### PR TITLE
docs: add dsh-telegram-channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ Management panel: Settings → Plugins.
 - [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) - Feishu bot.
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - Feishu notifications (session end / input needed).
 - [telegram](https://github.com/dsh-external/telegram) - Channel integration for Telegram.
+- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) - Telegram mobile remote for live DSH Web sessions: `/sessions` picker, bind/unbind, same trajectory as desktop (Codex-style).
 - [tg-bot](https://github.com/dsh-external/tg-bot) - Telegram bot.
 - [qqbot](https://github.com/dsh-external/qqbot) - QQ bot.
 - [dsh-wecom-bot](https://github.com/dsh-external/dsh-wecom-bot) - WeCom bot.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -252,6 +252,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) - 飞书机器人
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - 飞书通知（会话结束/等待输入）
 - [telegram](https://github.com/dsh-external/telegram) - Telegram 频道
+- [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) - Telegram 手机遥控器：附着本机正在运行的 DSH Web 会话（`/sessions` 选择、绑定/解绑），与电脑同轨迹（Codex 风格）。
 - [tg-bot](https://github.com/dsh-external/tg-bot) - Telegram bot
 - [qqbot](https://github.com/dsh-external/qqbot) - QQ bot
 - [dsh-wecom-bot](https://github.com/dsh-external/dsh-wecom-bot) - 企业微信 bot


### PR DESCRIPTION
## Summary
- Add [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) under **Notifications & Channels** (EN + zh-CN).
- Telegram mobile remote for **live** DSH Web sessions: `/sessions` bind/unbind, same trajectory as desktop.

## Install
```powershell
dsh plugin --profile web add github:hi-wenw/dsh-telegram-channel
```

## Checklist
- [x] Real public repository with `dsh.bundle.patch`
- [x] Topic: `dsh-plugin`
- [x] One-line factual description in both language READMEs