### PR TITLE
docs: add task-passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Management panel: Settings → Plugins.
 - [dsh-memory-vault](https://github.com/flymysql/dsh-memory) - Cross-session memory vault: memory_remember / memory_recall / memory_forget tools, latest entries injected into system-prompt assembly, Settings page (记忆库 / Memory).
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) - Index-free read-only search across dsh/Codex/Claude Code/pi/OpenCode sessions.
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) - Cite past conversations across harnesses.
+- [task-passport](https://github.com/dongsheng123132/task-passport) - Carry durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex with machine-readable checkpoints and optimistic locking.
 - [dsh-session-cluster](https://github.com/dsh-external/dsh-session-cluster) - Session clustering.
 - [session-chatlog](https://github.com/dsh-external/session-chatlog) - Session chat logs.
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) - Memoria memory backend for dsh: 4 tools (observe/remember/search/recall) into a vector+graph memory layer (memoria) with namespace isolation, auto-write (turn-end observe + positive-feedback -> importance-5 remember) and hot-reload settings.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,6 +90,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-memory-vault](https://github.com/flymysql/dsh-memory) - 跨会话记忆库：memory_remember / memory_recall / memory_forget 三工具，最新条目自动注入系统提示词，设置页（记忆库 / Memory）管理。
 - [dsh-session-search](https://github.com/dsh-external/dsh-session-search) - 跨 dsh/Codex/Claude Code/pi/OpenCode 会话只读搜索，无索引
 - [cross-harness-cite](https://github.com/dsh-external/cross-harness-cite) - 跨 harness 引用历史对话
+- [task-passport](https://github.com/dongsheng123132/task-passport) - 通过机器可读检查点与乐观锁，在 DeepSeek Harness、WorkBuddy、Claude Code 和 Codex 之间交接持久任务状态。
 - [dsh-session-cluster](https://github.com/dsh-external/dsh-session-cluster) - 会话聚类
 - [session-chatlog](https://github.com/dsh-external/session-chatlog) - 会话聊天记录
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) - Memoria 记忆后端：为 dsh agent 提供 observe/remember/search/recall 四个工具，支持向量+图记忆、命名空间隔离、自动写入与配置热重载。


### PR DESCRIPTION
## What changed

Adds `task-passport` to Context & Search in both the English and Chinese READMEs.

## Why

The plugin carries durable task state across DeepSeek Harness, WorkBuddy, Claude Code and Codex using machine-readable checkpoints and optimistic locking. It already appears in the generated CATALOG.md; this PR promotes it to the hand-curated README.

## Verification

- Immutable source: https://github.com/dongsheng123132/task-passport/tree/61ab7881e09c23a930e676cd9e450fdef436b14c
- `package.json` declares `dsh.bundle.patch`; the referenced `cordis.patch.yml` exists at that commit
- Fresh checkout: `npm test` (15/15), `npm run check`, and `npm run pack:check` pass
- Both language entries added; `git diff --check` passes