### PR TITLE
docs: update dsh-remote entry to 0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Management panel: Settings → Plugins.
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - Headed browser embedded in the WebUI, model-driven (Codex-style, zero vision deps).
 - [dsh-browser](https://github.com/dsh-external/dsh-browser) - Chrome sidebar extension.
 - [dsh-deeplink](https://github.com/dsh-external/dsh-deeplink) - Open DSH WebUI sessions or workspaces directly from URL parameters.
-- [dsh-remote](https://github.com/flymysql/dsh-remote) - Remote workspace for DeepSeek Harness: connect a host over SSH (password or key), pick a remote workspace directory, and operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec tools.
+- [dsh-remote](https://github.com/flymysql/dsh-remote) - Multi-machine remote workspace: manage many SSH hosts, pick a local or remote workspace in the native Add-workspace flow (system folder / path browse), mirror a remote workspace to a real local folder, and operate it with rw_* tools.
 - [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) - LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts (npm: dsh-lan-access).
 - [ego-browser](https://github.com/dsh-external/ego-browser) - Browser agent.
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web bridge.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -194,7 +194,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - WebUI 内嵌有头浏览器，模型实时操控（Codex 式，0 视觉依赖）
 - [dsh-browser](https://github.com/dsh-external/dsh-browser) - Chrome 侧边栏扩展
 - [dsh-deeplink](https://github.com/dsh-external/dsh-deeplink) - 通过 URL 参数直接打开 DSH WebUI 会话或工作区。
-- [dsh-remote](https://github.com/flymysql/dsh-remote) - DeepSeek Harness 远程工作区：SSH 连接主机（密码或密钥）、选择远端工作目录，通过 rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec 工具操作。
+- [dsh-remote](https://github.com/flymysql/dsh-remote) - 多机远程工作区：管理多个 SSH 主机，在原生 Add-workspace 流程中选择本地或远程工作区（系统文件夹/路径浏览），把远程工作区镜像到本地真实文件夹，用 rw_* 工具操作。
 - [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) - 局域网访问：Web GUI 绑定 0.0.0.0 + crypto.randomUUID polyfill（修复非安全上下文下 RPC 崩溃），npm 可装
 - [ego-browser](https://github.com/dsh-external/ego-browser) - 浏览器代理
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web 桥接


### PR DESCRIPTION
Update the dsh-remote entry to v0.5 (multi-machine remote workspace):

manage many SSH hosts; in the native Add-workspace flow you can pick a local workspace (system folder / local path) or a remote one (pick a machine, browse its directories); a chosen remote workspace is mirrored to a real local folder (fs.realpath) and adopted, synced over SFTP with rw_* tools.

Repo: https://github.com/flymysql/dsh-remote · npm: dsh-remote (v0.5).