### PR TITLE
docs: add dsh-im-hub

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -244,6 +244,7 @@
 | [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) | 飞书 remote channel |
 | [dsh-ica](https://github.com/dsh-external/dsh-ica) | dsh 接 icalingua（QQ 客户端）前端（推断：IM 渠道，待作者确认） |
 | [dsh-wecom-bot](https://github.com/dsh-external/dsh-wecom-bot) | 企业微信 remote channel |
+| [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) | 多平台 IM 网关：飞书（Lark）WebSocket 长连接、企业微信加密回调、Telegram 长轮询；每会话独立 agent、白名单访问、默认无需公网地址 |
 | [dsh-weixin-bot](https://github.com/dsh-external/dsh-weixin-bot) | 微信 remote channel |
 | [qqbot](https://github.com/dsh-external/qqbot) | QQ remote channel |
 | [telegram](https://github.com/dsh-external/telegram) | Telegram Bot API 桥接（长轮询、per-chat 会话） |

--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Management panel: Settings → Plugins.
 - [tg-bot](https://github.com/dsh-external/tg-bot) - Telegram bot.
 - [qqbot](https://github.com/dsh-external/qqbot) - QQ bot.
 - [dsh-wecom-bot](https://github.com/dsh-external/dsh-wecom-bot) - WeCom bot.
+- [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) - Multi-platform IM gateway: Feishu (Lark) WebSocket long connection, WeCom (WeChat Work) encrypted callbacks, and Telegram long polling; per-chat agent sessions, whitelist access, no public endpoint required.
 - [dsh-weixin-bot](https://github.com/dsh-external/dsh-weixin-bot) - WeChat bot.
 - [dsh-voice-chat](https://github.com/dsh-external/dsh-voice-chat) - Voice chat.
 - [dsh-web-ui-notify](https://github.com/dsh-external/dsh-web-ui-notify) - WebUI notifications.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -257,6 +257,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [tg-bot](https://github.com/dsh-external/tg-bot) - Telegram bot
 - [qqbot](https://github.com/dsh-external/qqbot) - QQ bot
 - [dsh-wecom-bot](https://github.com/dsh-external/dsh-wecom-bot) - 企业微信 bot
+- [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) - 多平台 IM 网关：飞书（Lark）WebSocket 长连接、企业微信加密回调、Telegram 长轮询；每会话独立 agent、白名单访问、默认无需公网地址。
 - [dsh-weixin-bot](https://github.com/dsh-external/dsh-weixin-bot) - 微信 bot
 - [dsh-voice-chat](https://github.com/dsh-external/dsh-voice-chat) - 语音对话
 - [dsh-web-ui-notify](https://github.com/dsh-external/dsh-web-ui-notify) - WebUI 通知


### PR DESCRIPTION
Add [dsh-im-hub](https://github.com/ThreeBody6666/dsh-im-hub) to README.md / README.zh-CN.md (Notifications & Channels) and CATALOG.md.

**dsh-im-hub** is a multi-platform IM gateway bundle for DeepSeek Harness: Feishu (Lark) WebSocket long connection, WeCom (WeChat Work) encrypted callbacks, and Telegram long polling. Per-chat agent sessions, whitelist access, no public endpoint required.