### PR TITLE
docs: add dsh-reverse-skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - Generate interactive OpenMAIC AI classrooms.
 - [dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -337,6 +337,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - 生成 OpenMAIC 交互式 AI 课堂。
 - [dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。
+- [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究技能路由包。
 
 ## Related
 


### PR DESCRIPTION
Add [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) to the curated list under **Science & Research** (both the English and 简体中文 READMEs).

- Complete port of the reverse-skill pack — **85 `SKILL.md`** (43 domain skills + 42 CTF) — into a DeepSeek Harness Cordis plugin.
- Registers every skill through the `ctx.skills` seam; covers reverse engineering, authorized pentesting and security research.
- Repo already carries the `dsh-plugin` topic, so it also surfaces in the auto-generated `CATALOG.md`.

Per `contributing.md`: real repo, one-line factual description, link only, and both language versions are updated in this single PR.