### PR TITLE
docs: add Code2Skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Management panel: Settings → Plugins.
 
 ## Infrastructure & Development
 
+- [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) - Unofficial in-process Windows desktop app with tray residency, native notifications, and an IPC bridge.
 - [dsh-hmz](https://github.com/dsh-external/dsh-hmz) - Placeholder repository; description pending.
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - Interpreter plugin (cordis).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -294,6 +294,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Infrastructure & Development
 
+- [Code2Skill](https://github.com/leechen298/Code2Skill) - 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) - 非官方 Windows 进程内桌面应用，提供托盘常驻、原生通知与 IPC 桥接。
 - [dsh-hmz](https://github.com/dsh-external/dsh-hmz) - 占位仓库，描述待补充。
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - 解释器插件（cordis）。


### PR DESCRIPTION
## Summary

Add Code2Skill v1.1.3 to the English and Chinese Infrastructure & Development sections. Code2Skill is an installable DeepSeek Harness bundle that generates Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.

## Verification

- Updated both language versions with matching factual descriptions.
- Confirmed the canonical repository declares `dsh.bundle`, includes `cordis.patch.yml`, and has the `dsh-plugin` topic.
- Ran `git diff --check`.

Install documentation: `dsh plugin --profile web add github:leechen298/Code2Skill#v1.1.3`
