### PR TITLE
docs: add dsh-lark-meeting-notifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) - Feishu bot.
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - Feishu notifications (session end / input needed).
+- [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) - Feishu meeting reminder: a right-side floating panel listing today's/tomorrow's Feishu meetings with multi-alarm flashing reminders.
 - [telegram](https://github.com/dsh-external/telegram) - Channel integration for Telegram.
 - [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) - Telegram mobile remote for live DSH Web sessions: `/sessions` picker, bind/unbind, same trajectory as desktop (Codex-style).
 - [tg-bot](https://github.com/dsh-external/tg-bot) - Telegram bot.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -257,6 +257,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) - 飞书机器人
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - 飞书通知（会话结束/等待输入）
+- [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) - 飞书会议提醒：右侧悬浮框显示今日/明日飞书会议，多闹钟闪烁提醒。
 - [telegram](https://github.com/dsh-external/telegram) - Telegram 频道
 - [dsh-telegram-channel](https://github.com/hi-wenw/dsh-telegram-channel) - Telegram 手机遥控器：附着本机正在运行的 DSH Web 会话（`/sessions` 选择、绑定/解绑），与电脑同轨迹（Codex 风格）。
 - [tg-bot](https://github.com/dsh-external/tg-bot) - Telegram bot


### PR DESCRIPTION
Add [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) — a Feishu meeting reminder plugin (right-side floating panel, today's/tomorrow's meetings, multi-alarm flashing reminders).

- Added to both `README.md` (English) and `README.zh-CN.md` (Chinese) under **Notifications & Channels**.
