### PR TITLE
Add dsh-computer-use under Browser & Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Management panel: Settings → Plugins.
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web bridge.
 - [browser4-dsh](https://github.com/dsh-external/browser4-dsh) - Browser4 AI-native browser engine (skills).
 - [dsh-browser-runtime](https://github.com/anweat/dsh-browser) - Self-contained browser runtime plugin: Playwright (chromium) + OpenCLI as plugin-local deps (global reuse fallback), exposes a `browser` service and interactive browser tools.
+- [dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) - Text-first computer use: background Chromium control via Playwright/CDP plus accessibility-first macOS control; actions stay pinned to the correct process and window without taking the user's pointer (Developer ID signed, notarized Universal 2 DMG).
 
 
 ## Models & Inference

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,6 +206,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web 桥接
 - [browser4-dsh](https://github.com/dsh-external/browser4-dsh) - Browser4 AI-native 浏览器引擎（skills）
 - [dsh-browser-runtime](https://github.com/anweat/dsh-browser) - DSH 自包含浏览器运行时插件：Playwright（chromium）+ OpenCLI 作为插件本地依赖（全局复用回退），提供 `browser` 服务与交互式浏览器工具。
+- [dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) - 文本优先电脑控制：Playwright/CDP 后台操作 Chromium，Accessibility 优先控制 macOS；动作锁定到正确进程与窗口，不抢前台、不移动鼠标（已签名公证 Universal 2 DMG 安装包）。
 
 
 ## Models & Inference


### PR DESCRIPTION
Adds [dsh-computer-use](https://github.com/ZRui-C/dsh-computer-use) to the **Browser & Remote** section of the EN and ZH listings.

**What it is:** Text-first computer use for DeepSeek Harness — background Chromium control via Playwright/CDP plus accessibility-first macOS control. Actions stay pinned to the correct process and window without taking the user's pointer.

- Ships a Developer ID signed, Apple-notarized Universal 2 DMG installer with SHA-256 checksums
- DSH bundle via `cordis.patch.yml` (`computer_observe` / `computer_action` tools), Apache-2.0
- Repo tagged with `dsh-plugin` / `deepseek-harness` topics (auto-indexed in CATALOG)
- Product site: https://computer-use.zrui.tech/