### PR TITLE
docs: add DeepSeek Harness Handbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue aggregation hub.
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual.
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - Agent-first, source-backed guide to running, extending, and troubleshooting DSH, with multilingual navigation and a downloadable field guide.
 - [DeepSeek](https://deepseek.com) - Official site.
 
 ## Contributing

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -348,6 +348,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue 聚合仓库
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - 社区整活插件导航（皮肤/桌宠/小游戏），中英双语
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 从 Agent 视角讲解 DSH 运行、扩展与排障的来源可追溯手册，提供多语言导航和可下载的速查指南
 - [DeepSeek](https://deepseek.com) - 官方入口
 
 ## Contributing


### PR DESCRIPTION
## Summary

Adds the DeepSeek Harness Handbook to the Related section in both the English and Simplified Chinese READMEs.

The handbook complements this plugin catalog with source-backed guidance for:

- first Web and headless runs
- runtime composition and durable session events
- tools, approvals, and sandbox boundaries
- MCP, skills, subagents, and Python embedding
- Windows compatibility and symptom-led troubleshooting

The entry follows the repository + factual one-line description format and links to a live public repository.
