### PR TITLE
docs: add dsh-llm-fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Management panel: Settings → Plugins.
 - [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - Per-call model / provider / persona / toolFilter overrides for subagent delegation, @preset: references, provider/model composite ids (bundle, no patched files).
 - [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - Extends dsh-subagent-tools with a per-call cwd for subagents and the two in-process provider patches it requires.
 - [dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) - Subscription OAuth login: use ChatGPT/Claude/Grok/Kimi subscription accounts (not API keys) with automatic model discovery.
+- [dsh-llm-fallback](https://github.com/Visol-456/dsh-llm-fallback) - Provider fallback chain: the request head is never rewritten (your picked model stays); on switchable failure it retries through the configured backup targets in order, with a Web UI settings panel.
 
 ## Git & Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -228,6 +228,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-subagent-tools](https://github.com/lynx-gt/dsh-subagent-tools) - 子代理委派按次覆盖 model / provider / persona / toolFilter、@preset: 引用、provider/model 复合 id（bundle，不改官方文件）。
 - [dsh-subagent-cwd](https://github.com/lynx-gt/dsh-subagent-cwd) - dsh-subagent-tools 加按次 cwd（子代理工作目录），附所需的两处进程内 provider 补丁。
 - [dsh-subscription-auth](https://github.com/Khellendros97/dsh-subscription-auth) - 订阅会员 OAuth 登录：ChatGPT/Claude/Grok/Kimi 按订阅账号（非 API key）访问模型，登录后自动发现官方模型列表
+- [dsh-llm-fallback](https://github.com/Visol-456/dsh-llm-fallback) - Provider 回退链：请求本身永远是链头（你选的模型永不被改写），失败按备用目标顺序自动切换重试；带 Web UI 配置面板
 
 ## Git & Engineering
 


### PR DESCRIPTION
## What

Add [dsh-llm-fallback](https://github.com/Visol-456/dsh-llm-fallback) to the **Models & Inference** category (both English and Chinese READMEs).

## Entry

- **dsh-llm-fallback** - Provider fallback chain: the request head is never rewritten (the model you pick in the chat bar stays); on switchable failure (timeout / rate limit / server error / empty response / UNKNOWN_MODEL) the same request retries through the configured backup targets in order.
- Web UI settings panel: provider/model dropdowns (driven by each provider's configured model list), switch codes, failure threshold, cooldown — saves to `~/.dsh/settings.yaml`, hot-applies on the next request.
- Declares `dsh.bundle`, published on npm (`@visol-456/dsh-llm-fallback` v0.1.1); 69 unit tests passing, verified on a real Windows web profile.