### PR TITLE
docs: add dsh-xiaohongshu-viral-note

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ Management panel: Settings → Plugins.
 
 
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - Export the append-only session log as human-readable Markdown or HTML, grouped by trajectory source.
+- [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) - Bundled Xiaohongshu/RED viral-note agent skill: hot-note research, note generation/rewrite, verification, authorized account analysis, QR login and controlled publishing.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -255,6 +255,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - 把 append-only 会话日志导出为人可读的 Markdown/HTML，按轨迹来源（系统提示/思维链/工具调用/子 agent）分组。
+- [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) - 小红书爆款笔记 agent skill 插件：热门笔记研究、选题、种草文案生成/改写、合规校验、授权账号权重分析、扫码登录与受控发布。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Add [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) to the Output & Deliverables section (EN + ZH).`n`nDSH bundle plugin shipping the Xiaohongshu/RED viral-note agent skill as a bundled skill provider (official skill-badge pattern): hot-note research, note generation/rewrite, verification, authorized account analysis, QR login and controlled publishing. Verified end-to-end: install via `dsh plugin --profile web add "github:xuboboo/dsh-xiaohongshu-viral-note"`, skill discovered and loadable through ctx.skills.