### PR TITLE
docs: add dsh-grok-geo

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Management panel: Settings → Plugins.
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - Generate interactive OpenMAIC AI classrooms.
 - [dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.
 - [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
+- [dsh-grok-geo](https://github.com/xuboboo/dsh-grok-geo) - GEO brand audit skill bundle: AI-search visibility, recommendations, citations, competitor presence and content-gap diagnosis across 17+ AI engines (ChatGPT/Perplexity/Claude/豆包/DeepSeek/Kimi/文心一言).
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -343,6 +343,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - 生成 OpenMAIC 交互式 AI 课堂。
 - [dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。
 - [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究技能路由包。
+- [dsh-grok-geo](https://github.com/xuboboo/dsh-grok-geo) - GEO 品牌审计 skill 插件：覆盖 17+ AI 搜索引擎（ChatGPT/Perplexity/Claude/豆包/DeepSeek/Kimi/文心一言）的 AI 搜索可见性、推荐、引用、竞品对比与内容缺口诊断。
 
 ## Related
 


### PR DESCRIPTION
Add [dsh-grok-geo](https://github.com/xuboboo/dsh-grok-geo) to the Science & Research section (EN + ZH).`n`nDSH bundle plugin shipping the grok-geo GEO brand audit skill as a bundled skill provider (official skill-badge pattern): AI-search visibility, recommendations, citations, competitor presence and content-gap diagnosis across 17+ AI engines. Verified end-to-end: install via `dsh plugin --profile web add "github:xuboboo/dsh-grok-geo"`, skill discovered and loadable through ctx.skills.