### PR TITLE
Add dsh-bash-rtk to Git & Engineering (EN + zh-CN)

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Management panel: Settings → Plugins.
 - [dsh-gh-bridge](https://github.com/dsh-external/dsh-gh-bridge) - Bridge macOS Keychain GitHub token into sandboxed gh.
 - [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) - GitHub Action that runs DeepSeek Harness for pull request review, CI diagnosis, trusted fixes, and issue-to-PR implementation.
 - [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) - Auto blame.
+- [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - Routes eligible bash commands through rtk (Rust Token Killer) inside the DSH bash executor to compress tool output and save tokens; safe passthrough when rtk is absent.
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - Structured Git tools (status/diff/log/branch/stage/commit/stash/show) with a destructive-command guard.
 - [dsh-plugin-check](https://github.com/dsh-external/dsh-plugin-check) - Plugin health checks (manifest/patch format/build pitfalls/hub status).
 - [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) - Redacts supported secret patterns from the `session-telemetry/record` export copy before configured telemetry backends receive it.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -235,6 +235,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-gh-bridge](https://github.com/dsh-external/dsh-gh-bridge) - macOS Keychain GitHub token 桥入 sandbox gh
 - [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) - 在 GitHub 中运行 DeepSeek Harness，用于 PR 审查、CI 诊断、受信任修复和 Issue → PR。
 - [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) - 自动 blame
+- [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - 在 DSH bash 执行器内把符合条件的 bash 命令路由给 rtk（Rust Token Killer）以压缩工具输出、节省 token；rtk 缺失时安全透传。
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - 结构化 Git 工具（status/diff/log/branch/stage/commit/stash/show）+ 破坏性命令安全护栏
 - [dsh-plugin-check](https://github.com/dsh-external/dsh-plugin-check) - 插件健康检查（清单/patch 格式/构建陷阱/hub 收录）
 - [dsh-telemetry-redactor](https://github.com/030611/dsh-telemetry-redactor) - 在已配置遥测后端接收前，对 `session-telemetry/record` 导出副本中的已支持秘密模式进行脱敏。


### PR DESCRIPTION
Hi maintainers,

Thank you for putting together this curated list and the clear contribution guide.

I would like to add **dsh-bash-rtk**, a DeepSeek Harness plugin:

- Repo: https://github.com/DeepTrial/dsh-bash-rtk
- What it does: routes eligible bash commands through [rtk](https://github.com/rtk-ai/rtk) (Rust Token Killer) inside the DSH bash executor to compress verbose tool output (git, cargo, pytest, docker, etc.) and reduce token usage. Complex commands, unknown tools, and runs without rtk on PATH pass through unchanged, so it is safe to enable.
- Compatibility: tested against DeepSeek Harness 0.1.0-rc.x; it requires an externally managed `rtk` binary on PATH.
- Entry standard: it is a real, public, MIT-licensed repository, with a one-line factual description and a direct link, placed alphabetically in the Git & Engineering section.

Per your contributing guide, I updated both README.md (English) and README.zh-CN.md (Chinese) in this same PR with matching entries.

Please let me know if you would prefer a different category, wording, or any additional detail. Thanks for your time and for maintaining the list.