### PR TITLE
Add dsh-equip-engine: task-driven plugin equip engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Management panel: Settings → Plugins.
 - [dsh-client-ui-plan-execute](https://github.com/dsh-external/dsh-client-ui-plan-execute) - Web Settings row for plan/execute model routing.
 
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic workflow for DSH (placeholder).
+- [dsh-equip-engine](https://github.com/wuykjl/dsh-equip-engine) - Task-driven plugin equip engine: dual retrieval (curated rules + LLM semantic), combo scoring (synergy/conflict/cost/trust), conflict detection and install-command export. 配装引擎：按任务自动配整套插件，区别于目录/搜索。
+
 ## Context & Search
 
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) - Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi; the model decides when and what to compress.


### PR DESCRIPTION
Add [dsh-equip-engine](https://github.com/wuykjl/dsh-equip-engine) to Core category.

Task-driven plugin equip engine for DSH: dual retrieval (curated rules + LLM semantic), combo scoring (synergy/conflict/cost/trust), conflict detection, and install-command export. Distinct from directory/search tools — recommends a whole plugin set per task.

- dsh-plugin topic added
- cordis.patch.yml bundle declared
- MIT licensed