### PR TITLE
docs: add dsh-clawrouter

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Management panel: Settings → Plugins.
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) - Free vision for text-only agents: built-in keyless vision chain plus pixel tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots); paste an image and it just works — no Python, one-command install.
 - [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) - DeepSeek brain + automatic image transcription: attach images in the GUI and each one is transcribed to text via any OpenAI-compatible VLM before reaching the text-only DeepSeek — a keyed fast path (default qwen3.7-flash; DashScope/Zhipu/OpenRouter or any OpenAI-compatible endpoint) with your own key, or local Ollama auto-detected with zero config.
 - [dsh-advisor](https://github.com/dsh-external/dsh-advisor) - Second model passively reviews each turn and injects notes.
+- [dsh-clawrouter](https://github.com/BlockRunAI/dsh-clawrouter) - Blocking safety gate: a stronger model rules allow/deny/ask on risky tool calls, enforced by the tool executor rather than by prompt. Optional BlockRun x402 route for 67 models, paid per request from a wallet.
 - [dsh-llm-fallbacks](https://github.com/dsh-external/dsh-llm-fallbacks) - Role-based LLM retry/fallback strategy.
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - ExtensionAPI bridge for pi.
 - [dsh-a2a](https://github.com/dsh-external/dsh-a2a) - Agent2Agent mesh.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -215,6 +215,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [ysr666/dsh-vision-router](https://github.com/ysr666/dsh-vision-router) - 内置免 Key 视觉链 + 像素级视觉工具（看图问答、定位、裁剪、像素对比、取色、OCR、矢量化、抠图、截图）；粘贴图片即可用，无 Python，一条命令安装
 - [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy) - DeepSeek 大脑 + 自动识图：GUI 附加的每张图片自动经 OpenAI 兼容 VLM 转译成文字，再交给纯文本的 DeepSeek 作答——有 key 自动走快速通道（默认 qwen3.7-flash，支持百炼/智谱/OpenRouter 等任意 OpenAI 兼容端点），无 key 自动探测本地 Ollama（零配置，图片不出本机）。
 - [dsh-advisor](https://github.com/dsh-external/dsh-advisor) - 副模型每轮被动审查并注入建议
+- [dsh-clawrouter](https://github.com/BlockRunAI/dsh-clawrouter) - 阻断式安全闸门：更强的模型对危险工具调用给出放行/拒绝/询问，由工具执行器强制执行，而非提示词劝阻。可选 BlockRun x402 路由，一个钱包按次调用 67 个模型。
 - [dsh-llm-fallbacks](https://github.com/dsh-external/dsh-llm-fallbacks) - 角色化 LLM 重试/备用策略
 - [dsh-pi-adapter](https://github.com/dsh-external/dsh-pi-adapter) - pi ExtensionAPI 桥接
 - [dsh-a2a](https://github.com/dsh-external/dsh-a2a) - Agent2Agent mesh


### PR DESCRIPTION
Adds dsh-clawrouter to Models & Inference, in both language files.

Disclosure: I work on BlockRun and this is our plugin.

It sits next to dsh-advisor, which passively reviews each turn and injects notes. This one is blocking: the verdict is returned from a `tools/pre-execute` listener, so a denied call never reaches the tool function. It only ever narrows — a cleared call still faces the rest of the policy chain, and an escalation defers to a stricter downstream listener rather than overriding it.

Disabled by default, since intercepting tool execution should be the user's choice.

Measured, and asserted in the test suite rather than claimed:

- 39/39 destructive shell commands flagged, 0/59 false positives — including commands that only *mention* a destructive one, such as `grep -rn "rm -rf" docs/`
- 10/10 writes to files that execute later (git hooks, CI workflows, shell startup files, npm `postinstall`), 0/15 false positives on ordinary file edits
- Evasions covered: `\rm -rf /`, `command rm`, `env rm`, `eval "…"`, `bash -c "…"`, `| xargs rm`, and heredocs piped into a shell

The x402 route is optional and does not change the agent's default model.