### PR TITLE
docs: add dsh-atomgit

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-git-identity](https://github.com/dsh-external/dsh-git-identity) - Pin Git commit authorship to the environment identity (gh account + noreply email).
 - [dsh-gh-bridge](https://github.com/dsh-external/dsh-gh-bridge) - Bridge macOS Keychain GitHub token into sandboxed gh.
+- [dsh-atomgit](https://github.com/xiongjiamu/dsh-atomgit) - AtomGit plugin bundle for DeepSeek Harness: atomgit-skills workflows (plan/implement/review/merge issues & PRs), ag CLI, and platform-hosted GitCode MCP tools.
 - [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) - GitHub Action that runs DeepSeek Harness for pull request review, CI diagnosis, trusted fixes, and issue-to-PR implementation.
 - [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) - Auto blame.
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - Structured Git tools (status/diff/log/branch/stage/commit/stash/show) with a destructive-command guard.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -233,6 +233,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-git-identity](https://github.com/dsh-external/dsh-git-identity) - Git 提交固定环境作者身份（gh 登录账号 + noreply 邮箱）
 - [dsh-gh-bridge](https://github.com/dsh-external/dsh-gh-bridge) - macOS Keychain GitHub token 桥入 sandbox gh
+- [dsh-atomgit](https://github.com/xiongjiamu/dsh-atomgit) - AtomGit 插件 bundle：内置 atomgit-skills 工作流（规划/实现/审查/合并 Issue 与 PR）、ag CLI 与平台托管的 GitCode MCP 工具
 - [deepseek-harness-action](https://github.com/Lixiaoyiao/deepseek-harness-action) - 在 GitHub 中运行 DeepSeek Harness，用于 PR 审查、CI 诊断、受信任修复和 Issue → PR。
 - [dsh-auto-blame](https://github.com/dsh-external/dsh-auto-blame) - 自动 blame
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - 结构化 Git 工具（status/diff/log/branch/stage/commit/stash/show）+ 破坏性命令安全护栏


### PR DESCRIPTION
Add [dsh-atomgit](https://github.com/xiongjiamu/dsh-atomgit) to the **Git & Engineering** category.

## What it is

An installable plugin bundle (`dsh.bundle`) that brings AtomGit code hosting to DeepSeek Harness (dsh) with a single `dsh plugin --profile web add dsh-atomgit`. One install delivers three layers:

- **Workflow — six built-in skills** vendored from the atomgit-skills upstream (`atomgit-plan-issues`, `atomgit-implement-issue`, `atomgit-review-pr`, `atomgit-merge-pr`, `atomgit-publish-cli-release`, `atomgit-mirror-to-github`), registered as runtime skills in the model's `<available_skills>` catalog.
- **Execution — ag CLI integration**: the model drives AtomGit repos/issues/PRs/releases/actions directly through `ag` in bash.
- **Interaction — platform-hosted GitCode MCP tools**: native `mcp__gitcode__*` tools bridged over streamable-http to the AtomGit-hosted MCP endpoint (`https://api.gitcode.com/mcp-server/v1/mcp`) — no local MCP server, Docker, or Python required.

## Key properties

- **Unified authentication**: one PAT from `ag auth login` authenticates all three modules — ag/skills read the ag credential file directly, and the plugin's `atomgitAuth` service resolves the same token for the MCP endpoint (`GITCODE_TOKEN` env as optional override).
- **Zero local services**: the only setup is `ag auth login`.
- **Zero build step**: pure JS + Markdown, installable from npm or git without a build/allowlist dance.
- **Reproducible skills**: `scripts/sync-skills.sh` vendors the six skills pinned to an upstream tag; upstream license (`skills/LICENSE`) shipped alongside.

Both `README.md` and `README.zh-CN.md` were updated in the same commit with the entry and a translated description.