### PR TITLE
docs: add SandBase runtime and skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,8 @@ Management panel: Settings → Plugins.
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) - Unofficial in-process Windows desktop app with tray residency, native notifications, and an IPC bridge.
+- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) - Persistent managed-agent runtime for DSH via a native bundle and stdio MCP, with sandboxed sessions, audit, and replay.
+- [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - Verified SKILL.md catalog and installer with 88 installable skill bundles for DSH and compatible agents.
 - [dsh-hmz](https://github.com/dsh-external/dsh-hmz) - Placeholder repository; description pending.
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - Interpreter plugin (cordis).
 - [dsh-notebooks](https://github.com/dsh-external/dsh-notebooks) - Notebooks plugin (cordis).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -300,6 +300,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) - 非官方 Windows 进程内桌面应用，提供托盘常驻、原生通知与 IPC 桥接。
+- [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) - 通过原生 bundle 与 stdio MCP 接入 DSH 的持久化托管 Agent 运行时，提供沙箱会话、审计与回放。
+- [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 经校验的 SKILL.md 目录与安装器，为 DSH 和兼容 Agent 提供 88 个可安装技能包。
 - [dsh-hmz](https://github.com/dsh-external/dsh-hmz) - 占位仓库，描述待补充。
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - 解释器插件（cordis）。
 - [dsh-notebooks](https://github.com/dsh-external/dsh-notebooks) - notebooks 插件（cordis）。


### PR DESCRIPTION
## What changed

- Add `sandbase-harness` to the English and Chinese Infrastructure & Development sections.
- Add `sandbase-skills` alongside it as the verified skills catalog and installer.

## Why

Both repositories provide concrete DeepSeek Harness integrations: a native runtime/MCP bridge and 88 validated, installable `SKILL.md` bundles. The generated catalog already discovers `sandbase-harness`; this adds concise entries to the hand-curated bilingual list.

## Validation

- `git diff --check`
- Verified both repository links.
- Counted 88 `SKILL.md` files in `sandbase-skills`.
