### PR TITLE
docs: add dsh-collaboration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@
 
 - [Install](#install)
 - [Core](#core)
+- [Agents & Orchestration](#agents--orchestration)
 - [Context & Search](#context--search)
 - [Input & Editing](#input--editing)
 - [UI & Experience](#ui--experience)
@@ -80,6 +81,10 @@ Management panel: Settings → Plugins.
 - [dsh-client-ui-plan-execute](https://github.com/dsh-external/dsh-client-ui-plan-execute) - Web Settings row for plan/execute model routing.
 
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic workflow for DSH (placeholder).
+
+## Agents & Orchestration
+
+- [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
 ## Context & Search
 
 - [billion-context-dsh](https://github.com/Tyan66666/billion-context-dsh) - Model-driven context compression (ACP) for DeepSeek Harness, ported from billion-context-pi; the model decides when and what to compress.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,6 +34,7 @@
 
 - [Install](#install)
 - [Core](#core)
+- [Agents & Orchestration](#agents--orchestration)
 - [Context & Search](#context--search)
 - [Input & Editing](#input--editing)
 - [UI & Experience](#ui--experience)
@@ -79,6 +80,10 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-client-ui-plan-execute](https://github.com/dsh-external/dsh-client-ui-plan-execute) - Web 设置页「规划/执行模型」配置行
 
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic Workflow for dsh（占位）。
+
+## Agents & Orchestration
+
+- [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - 多智能体协同套件：用户可配置的专家名册 + 持久专家实例（可多分身）按需雇佣、星型拓扑追问/中转、团队状态面板、模型对比与多模态视觉桥。
 ## Context & Search
 
 - [context-vista](https://github.com/GooodWei/context-vista) - 为 DeepSeek Harness 提供右侧悬浮栏以及 /context 命令，用环形图实时展示当前上下文 token 用量与分配及消费估算


### PR DESCRIPTION
Adds [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) under a new **Agents & Orchestration** category (no existing category covers multi-agent collaboration plugins).

- Multi-agent collaboration suite for DeepSeek Harness: user-configurable specialist roster (ten identities), persistent specialist instances with clone support, star-topology team messaging, model comparison and a multimodal vision bridge.
- MIT licensed; bilingual README, Releases with tarball assets, CI green; installed as a host row + agent preset via the official composition.