### PR TITLE
docs: add dsh-wuyun-liuqi (wuyun-liuqi TCM skill pack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Management panel: Settings → Plugins.
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - Generate interactive OpenMAIC AI classrooms.
 - [dsh-science](https://github.com/biociao/dsh-science) - Claude Science-style research workbench: ReAct research-loop engine (research_* tools), versioned artifacts with provenance (artifact_* tools), and 10 science skills for genomics/pathogens/bioinformatics.
 - [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - Complete reverse-skill pack (85 SKILL.md) as a DeepSeek Harness Cordis plugin: reverse engineering, authorized pentesting and security-research skill router.
+- [dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - Complete wuyun-liuqi (five-evolutions-six-qi / 五运六气) Traditional Chinese Medicine skill pack as a DeepSeek Harness Cordis plugin: annual and guest-qi calculation, clinical pattern differentiation, and pathogenesis reasoning.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -343,6 +343,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-openmaic](https://github.com/dsh-external/dsh-openmaic) - 生成 OpenMAIC 交互式 AI 课堂。
 - [dsh-science](https://github.com/biociao/dsh-science) — 面向 DSH 的 Claude Science 式科研工作台：ReAct 研究循环引擎（research_* 工具）、带溯源的版本化工件（artifact_* 工具）与面向基因组/病原体/生物信息的 10 个科研技能。
 - [dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill) - 完整 reverse-skill（85 个 SKILL.md）的 DeepSeek Harness 插件：逆向工程、授权渗透测试与安全研究技能路由包。
+- [dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - 完整 wuyun-liuqi（五运六气）中医运气学技能包，封装为 DeepSeek Harness 插件：年度与客气推算、临床辨证、病机推演。
 
 ## Related
 


### PR DESCRIPTION
Following up on my earlier dsh-reverse-skill addition (#110) — companion DeepSeek Harness plugin, verified end-to-end locally.

**dsh-wuyun-liuqi** wraps [`dhicoc/wuyun-liuqi-skills`](https://github.com/dhicoc/wuyun-liuqi-skills) (五运六气 / five-evolutions-six-qi TCM) into a dsh Cordis plugin:
- 31 SKILL.md candidates (deduped) via the `ctx.skills` seam
- `dsh plugin add github:dhicoc/dsh-wuyun-liuqi` installs + activates via bundled `cordis.patch.yml`
- Verified: real Cordis `SkillService` mount + full `list()`/`get()` workflow, plus tarball install layout

Install: `dsh plugin add github:dhicoc/dsh-wuyun-liuqi`