### PR TITLE
docs: add BeiZi6/dsh-theme-plugin and BeiZi6/dsh-opencodego-usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Management panel: Settings → Plugins.
 - [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - Clickable file paths in DSH replies: Codex-style inline open, 📂 reveal in file manager, and a mentioned-files chip list at the turn tail.
 - [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - Auto-resumes interrupted DSH Web requests: sends a queued 「继续」 after network/timeout/host-crash failures, with error classification, adaptive backoff, templated continue text and browser notifications; everything configurable from the plugin settings card.
 - [dsh-trajectory-debug](https://github.com/devmom/dsh-trajectory-debug) - Trajectory waterfall, deterministic replay, breakpoints, edit-and-rerun, fork compare and performance analytics for DeepSeek Harness.
+- [dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) - Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage.
+- [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) - OpenCodeGo quota monitor for the DSH Web GUI: a breathing indicator at the input's bottom-right (green/yellow/red by remaining share), a liquid-glass panel with rolling/weekly/monthly usage windows and reset times, auto-refreshing every 30 s; API key read from DSH credentials.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -190,6 +190,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-file-mentions](https://github.com/a903067276-rgb/dsh-file-mentions) - 回复中的可点击文件路径：Codex 风格内联打开、📂 文件管理器显示、回合末尾的文件提及 chip 列表。
 - [dsh-auto-continue](https://github.com/HsiangNianian/dsh-auto-continue) - DSH Web 请求中断自动续跑：网络/超时/宿主崩溃等非人为失败后自动发送「继续」，支持错误分类、自适应退避、模板化继续文本与浏览器通知；全部参数可在插件设置卡片中调整。
 - [dsh-trajectory-debug](https://github.com/devmom/dsh-trajectory-debug) - DeepSeek Harness 轨迹瀑布流、确定性回放、断点、改参重跑、分叉对比与性能分析。
+- [dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) - DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。
+- [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) - OpenCodeGo 剩余额度监视器：输入框右下角呼吸指示灯（按剩余额度绿/黄/红），液态玻璃面板显示滚动/周/月用量窗口与重置时间，每 30 秒自动刷新；API Key 自动读取 DSH 凭据。
 
 ## IDE & Clients
 


### PR DESCRIPTION
Adds two plugins under **UI & Experience** (界面与体验), per [contributing.md](https://github.com/0xsline/awesome-deepseek-harness/blob/main/contributing.md): one-line factual entries in both README.md and README.zh-CN.md.

- [dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) — Theme studio for the DSH Web GUI: 5 built-in presets (codex-warm / nord / solarized / graphite / stock) plus fully customizable light/dark palettes (accent, background, foreground, UI & code fonts, translucent sidebar, contrast), instant hot-swap via the official `ctx.theme.overrideTokens` API, persisted in localStorage; official seams only (`webServer.tapIndex`), no patched vendor files. MIT, Node >= 22.19, `dsh.bundle` manifest, `dsh-plugin` topic set.
- [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) — OpenCodeGo quota monitor for the DSH Web GUI: breathing indicator at the input's bottom-right (green/yellow/red by remaining share), liquid-glass panel with rolling (≈5 h) / weekly / monthly usage windows and reset times, auto-refresh every 30 s; API key resolved automatically from DSH credentials (opencode-go provider) with manual override; the key is only ever sent to the official OpenCodeGo usage endpoint over HTTPS. MIT, Node >= 22.19, `dsh.bundle` manifest, `dsh-plugin` topic set.

Both repos are public, non-archived, actively maintained, and both already appear in the auto-generated topic section (CATALOG.md) via the `dsh-plugin` topic; this PR adds the hand-curated README entries.
