### PR TITLE
docs: add dsh-plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Management panel: Settings → Plugins.
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
+- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) - Planning-first agent preset: research repository changes into traceable Markdown plans, refine them through reviewer/criticizer subagent rounds, then execute as a DSH goal with a verifier checklist.
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,6 +86,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - 多智能体协同套件：用户可配置的专家名册 + 持久专家实例（可多分身）按需雇佣、星型拓扑追问/中转、团队状态面板、模型对比与多模态视觉桥。
+- [dsh-plans](https://github.com/Optim-Agent/dsh-plans) - 计划先行 Agent 预设：把仓库变更调研沉淀为 dsh-plans/ 下可追溯的 Markdown 计划，经 reviewer/criticizer 子代理多轮打磨，再作为 DSH goal 按验证清单执行。
 
 ## Context & Search
 


### PR DESCRIPTION
Adds the [dsh-plans](https://github.com/Optim-Agent/dsh-plans) planning-first agent preset under `Agents & Orchestration` in both `README.md` and `README.zh-CN.md`, following the contribution guide (one-line bilingual description, markdown-only).