### PR TITLE
Add dsh-movein (Infrastructure & Development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,7 @@ Management panel: Settings → Plugins.
 ## Infrastructure & Development
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
+- [dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH in one command: skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate, a migration diff report, and a movein_from_claude_code agent tool.
 - [dsh-observation-journal](https://github.com/Cavan-Ou/dsh-observation-journal) - Zero-touch runtime telemetry for DSH: every session auto-writes task, model tier, tools, failures, duration, status into a human-readable journal with a stats section (pure observer — no tools, no LLM calls, no injection).
 - [deepseek-harness-desktop](https://github.com/Easyhoov/deepseek-harness-desktop) - Unofficial in-process Windows desktop app with tray residency, native notifications, and an IPC bridge.
 - [sandbase-harness](https://github.com/sandbaseai/sandbase-harness) - Persistent managed-agent runtime for DSH via a native bundle and stdio MCP, with sandboxed sessions, audit, and replay.


### PR DESCRIPTION
dsh-movein moves a whole Claude Code setup into DSH in one command. Skills (SKILL.md loads as is), .mcp.json converted to dsh-mcp-client rows, hooks via the first party dsh-hooks-claude-code bridge, subagents converted to skills, and permission deny/ask rules enforced at the tools/pre-execute gate. Dry run by default with a migration diff report. Installable via dsh plugin add (registers a movein_from_claude_code tool) or npx.

npm https://www.npmjs.com/package/dsh-movein