### PR TITLE
docs: add dsh-agent-team-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Management panel: Settings → Plugins.
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,6 +86,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - 多智能体协同套件：用户可配置的专家名册 + 持久专家实例（可多分身）按需雇佣、星型拓扑追问/中转、团队状态面板、模型对比与多模态视觉桥。
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - 可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。
 
 ## Context & Search
 


### PR DESCRIPTION
## Summary

Adds dsh-agent-team-gui to **Agents & Orchestration** in the English and Simplified Chinese curated lists.

The entry is factual and concise: reusable squads, independent provider/model routes and tool policies for each agent, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.

## Validation

- Canonical repository is public and tagged dsh-plugin.
- The plugin declares an installable dsh.bundle manifest.
- Both language lists contain matching entries.
- Markdown diff check passes.