### PR TITLE
docs: add mirage-dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,7 @@ Management panel: Settings → Plugins.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) - Shared multi-agent task board (create / claim / transition / query) over a Cordis service key.
 
 - [dsh-tray](https://github.com/KAIbsb/dsh-tray) - Windows tray manager for DSH Web: start/restart/stop, crash auto-restart, status icon, and autostart.
+- [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.
 
 ## Data & Market
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -395,6 +395,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) - 多 agent 共享任务板（创建/认领/流转/查询），状态物化为 Cordis 协作用键。
 
 - [dsh-tray](https://github.com/KAIbsb/dsh-tray) - Windows 托盘管理器:启动/重启/停止 DSH Web、崩溃自动拉起、状态图标与开机自启。
+- [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
 
 ## Data & Market
 


### PR DESCRIPTION
Adds `mirage-dsh` to **Infrastructure & Development** in both `README.md` and `README.zh-CN.md`.

`@struktoai/mirage-dsh` is a bundle (`dsh.bundle.patch`) that replaces the filesystem and bash providers with a [mirage](https://github.com/strukto-ai/mirage) virtual workspace, so dsh's file tools and its bash tool operate on mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) rather than the host disk.

- npm: https://www.npmjs.com/package/@struktoai/mirage-dsh
- Docs: https://docs.mirage.strukto.ai/typescript/agents/dsh
- Source: https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh

Linked to the monorepo subdirectory, following the existing `create-dsh-plugin` / `plugin-manager` / `plugin-team-board` entries.

Note for the maintainer: `strukto-ai/mirage` already appears in `CATALOG.md` from the `dsh-plugin` topic, but falls into `其他` because it has no `TOPIC_MANUAL` mapping in `scripts/generate-catalog.py`. `开发与工程` would be the right bucket if you want to add it on the next catalog refresh. I left the generated catalog and the script untouched.