### PR TITLE
docs: update toolclub/dsh-agent-team-gui squad workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Management panel: Settings → Plugins.
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - Reusable agent squads with per-agent provider/model routes and tool policies, serial/parallel dispatch, spawn/fork/chain context modes, and a Web management panel.
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
 
 ## Context & Search
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Management panel: Settings → Plugins.
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
+- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) - Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,7 +86,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - 多智能体协同套件：用户可配置的专家名册 + 持久专家实例（可多分身）按需雇佣、星型拓扑追问/中转、团队状态面板、模型对比与多模态视觉桥。
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - 可复用 Agent 小队：每个成员独立配置 provider/model 路由与工具策略，支持串行/并行派单、spawn/fork/chain 上下文模式和 Web 管理面板。
+- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -86,7 +86,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Agents & Orchestration
 
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - 多智能体协同套件：用户可配置的专家名册 + 持久专家实例（可多分身）按需雇佣、星型拓扑追问/中转、团队状态面板、模型对比与多模态视觉桥。
-- [dsh-agent-team-gui](https://github.com/toolclub/agent_team_gui) - 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
+- [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) - 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
 
 ## Context & Search
 


### PR DESCRIPTION
## Summary

Canonical repository: [toolclub/dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui)

Updates the already-merged **dsh-agent-team-gui** entries in the English and Simplified Chinese lists to match the shipped workflow: global persistent squads are managed in **Settings → Teams**, selected and toggled per conversation, and used through ordinary sends in a fixed or model-planned order.

## Why a follow-up

The original PR #158 was merged with an earlier “dispatch panel” description. The plugin UI and durable session-mode workflow have since been completed and verified, so this two-line documentation correction keeps the catalog factual.

## Catalog validation

- matching English and Simplified Chinese entries
- `git diff --check`

## Validation

Plugin commit [`936b241`](https://github.com/toolclub/dsh-agent-team-gui/commit/936b241) was verified with:

- host/client build and full TypeScript checks;
- 30 tests across four test files;
- package tarball inspection;
- pinned Git-SHA install plus `dsh --profile web --dump-config`;
- live Web RPC smoke tests for snapshot, Agent/squad CRUD, per-session mode, export, and import.
