### PR TITLE
docs: add ciceroyang/create-dsh-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,7 @@ Management panel: Settings → Plugins.
 
 ## Infrastructure & Development
 
+- [create-dsh-plugin](https://github.com/ciceroyang/create-dsh-plugin) - Scaffold a battle-tested DeepSeek Harness plugin (bundle, tool, runtime skill, tests, CI) in one command, zero dependencies.
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH in one command: skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate, a migration diff report, and a movein_from_claude_code agent tool.
 - [dsh-observation-journal](https://github.com/Cavan-Ou/dsh-observation-journal) - Zero-touch runtime telemetry for DSH: every session auto-writes task, model tier, tools, failures, duration, status into a human-readable journal with a stats section (pure observer — no tools, no LLM calls, no injection).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -349,6 +349,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Infrastructure & Development
 
+- [create-dsh-plugin](https://github.com/ciceroyang/create-dsh-plugin) - 一条命令生成实战验证过的 DSH 插件工程（bundle、工具、运行时 skill、单测、CI），零依赖免构建。
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [dsh-movein](https://github.com/sjh9714/dsh-movein) - 一条命令把整套 Claude Code 配置迁入 DSH：技能、MCP 服务器、hooks、子代理与权限规则，附 dry-run 迁移清单、迁移差异报告与 movein_from_claude_code 工具。
 - [dsh-observation-journal](https://github.com/Cavan-Ou/dsh-observation-journal) - 把 DeepSeek Harness 的零侵入运行事实遥测：每个会话自动把任务/模型档位/工具/失败/时长/状态写入人机共读观测卡并附统计区（纯观察者——零工具、零 LLM、零注入）。


### PR DESCRIPTION
Adds create-dsh-plugin under Infrastructure & Development (both languages).

Zero-dependency scaffold that generates a battle-tested DSH plugin project: host plugin with tool + runtime skill registration, pure-function lib, node:test suite, four-node CI, and the dsh.bundle manifest. Encodes community pitfalls documented in the dsh-report-studio tutorial.

- Repo: https://github.com/ciceroyang/create-dsh-plugin
- Topic: dsh-plugin
- Tests: 5/5, CI green across Node 18/20/22/24