### PR TITLE
docs: add dsh-genie (Infrastructure & Development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-tray](https://github.com/KAIbsb/dsh-tray) - Windows tray manager for DSH Web: start/restart/stop, crash auto-restart, status icon, and autostart.
 - [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.
+- [dsh-genie](https://github.com/swaylq/dsh-genie) - Promote a `cordis_define` dynamic package into a real installed bundle that survives restart; writes the package and registers the profile layer without pnpm, network, or a build authorization.
 
 ## Data & Market
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -396,6 +396,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-tray](https://github.com/KAIbsb/dsh-tray) - Windows 托盘管理器:启动/重启/停止 DSH Web、崩溃自动拉起、状态图标与开机自启。
 - [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
+- [dsh-genie](https://github.com/swaylq/dsh-genie) - 把 `cordis_define` 的动态包固化为可跨重启存活的正式组合包；写包与注册 profile 层均不需要 pnpm、联网或构建授权。
 
 ## Data & Market
 


### PR DESCRIPTION
One entry under **Infrastructure & Development**, added to `README.md` and `README.zh-CN.md` in the same PR, following the terse one-line standard.

**[dsh-genie](https://github.com/swaylq/dsh-genie)** — DSH's own `cordis_define` / `cordis_run` let an agent write a plugin and hot-load it, but that toolset's README states plainly that a dynamic package "cannot be promoted automatically" and does not survive a restart. This closes that: `genie_keep` reads the package back out of the live runtime and writes it as a real installable bundle, `genie_wish` does the same for code written directly, `genie_revoke` and `/wish` manage the result.

The install path writes into `$DSH_HOME/genie/`, links it where the launcher already resolves modules, and appends one name to `dsh.profile.bundles` — no pnpm, no network, no `allowBuilds` grant.

Entry standard:
- Real repository, MIT, public, carries the `dsh-plugin` topic.
- Verified end to end against `@deepseek-ai/dsh@0.1.0-rc.6`: install from GitHub, boot, grant a wish, restart, it loads; revoke, restart, it is gone. 19 unit tests, no network.
- Description is factual, no badges or screenshots in the entry.