### PR TITLE
docs: add DSH Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-open-editor](https://github.com/Civitasv/dsh-plugin-open-editor) - Open the current workspace in your local editor (VS Code, Cursor, JetBrains, Vim, ...) from the session header.
 - [DSH-for-VSC](https://github.com/yauntyour/DSH-for-VSC) - VS Code extension embedding the DSH WebUI as an editor panel: sidebar console with service status and start/stop, hidden auto-restart, status-bar indicator and run logs.
 - [dsh-gui](https://github.com/xuboboo/dsh-gui) - Third-party Windows desktop client for DeepSeek Harness: native window, branded theme & splash, startup crash fixes, token usage statistics.
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform Rust/Tauri desktop shell that supervises `dsh web`, reclaims process trees, selects free ports, and publishes Windows/Linux/macOS installers without forking the upstream UI.
 
 ## Browser & Remote
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -225,6 +225,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-plugin-open-editor](https://github.com/Civitasv/dsh-plugin-open-editor) - 从会话页头一键用本地编辑器（VS Code / Cursor / JetBrains / Vim 等）打开当前项目。
 - [DSH-for-VSC](https://github.com/yauntyour/DSH-for-VSC) - 把 DSH 的 WebUI 搬进 VS Code：编辑器内嵌面板 + 侧边栏控制台（服务状态/一键启停），离线自动拉起、日志随时可查、状态栏常驻指示。
 - [dsh-gui](https://github.com/xuboboo/dsh-gui) - DeepSeek Harness 第三方 Windows 桌面客户端：原生窗口、品牌主题与启动动画、启动崩溃修复、Token 用量统计。
+- [DSH Studio](https://github.com/Moresyl/dsh-studio) - 跨平台 Rust/Tauri 桌面外壳：托管 `dsh web`、回收进程树、自动选择空闲端口，并发布 Windows/Linux/macOS 安装包，无需 fork 上游 UI。
 
 ## Browser & Remote
 


### PR DESCRIPTION
Adds [DSH Studio](https://github.com/Moresyl/dsh-studio) to the **IDE & Clients** section.

DSH Studio is a cross-platform Rust/Tauri desktop shell for DeepSeek Harness. It supervises `dsh web`, reclaims child process trees, selects an available port, and publishes installers for Windows, Linux, and both macOS architectures without forking the upstream UI.

- Updated both English and Chinese README files
- Kept each description factual and to one line
- Linked directly to the public repository