### PR TITLE
Add dsh-MusicPlayer to Fun & Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,8 @@ Management panel: Settings → Plugins.
 - [dsh-sfw](https://github.com/dsh-external/dsh-sfw) - Safety filter.
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - Custom status labels for the whale's deep-diving (cordis).
 
+- [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.
+
 ## Infrastructure & Development
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -347,6 +347,9 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-sfw](https://github.com/dsh-external/dsh-sfw) - 安全过滤
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - 鲸鱼娘思考状态自定义标签（cordis）
 
+
+- [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
+
 ## Infrastructure & Development
 
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。


### PR DESCRIPTION
Add [dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) under **Fun & Lifestyle** in both README.md and README.zh-CN.md.

**dsh-MusicPlayer** is a floating music player plugin for DeepSeek Harness Web: collapsible/expandable draggable frosted-glass card, NetEase Cloud Music playlist import (link/ID) and song/artist search with one-click add, multi-layer audio source resolution (Meting → outer/url), and an agent-facing music tool — chat and listen at the same time.

Per contributing guidelines:
- [x] Real repository with working code (declares dsh.bundle manifest)
- [x] One-line factual descriptions in both EN and zh-CN
- [x] dsh-plugin topic added