### PR TITLE
docs: add PerryLink/dsh-composer-history

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Management panel: Settings → Plugins.
 
 
 
+- [PerryLink/dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) - Terminal-style input history for the web composer: edge-first arrow-key recall with exact draft/caret restore, browser-local persisted history, Ctrl+R reverse search, and sliding-context awareness (compaction summaries join recall and search).
+
 ## UI & Experience
 
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - Keyboard-first command palette for DeepSeek Harness Web.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -153,6 +153,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-attachment-upload](https://github.com/lbh1nb/dsh-plugins/tree/main/packages/dsh-attachment-upload) - 输入框「📎 附件」按钮：上传文件到当前工作区 .dsh-attachments 并把路径插入草稿。
 - [dsh-steer-button](https://github.com/lbh1nb/dsh-plugins/tree/main/packages/dsh-steer-button) - 输入框常驻「插话」按钮：一键把草稿注入运行中的轮次（等同 Ctrl/Cmd+Enter）。
 
+- [PerryLink/dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) - 为 Web 作曲器提供终端风格输入历史：边缘优先方向键召回并精确还原草稿与光标、浏览器本地持久化历史、Ctrl+R 反向搜索与滑动上下文感知（压缩摘要加入召回与搜索）。
+
 ## UI & Experience
 
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - DeepSeek Harness Web 的键盘优先命令面板。


### PR DESCRIPTION
Adds dsh-composer-history to the **Input & Editing** category (composer input tooling) in both README.md and README.zh-CN.md.

One-line factual description, matching the entry standard in contributing.md: real repository, terse functional description, no badges or marketing.

- EN: terminal-style input history for the web composer (edge-first arrow recall with exact draft/caret restore, persisted history, Ctrl+R reverse search, sliding-context awareness).
- ZH: translation of the same entry.

The repo is already part of the dsh-plugin topic and appears in the generated CATALOG.md; this PR adds the hand-curated README entry.