### PR TITLE
docs: add dsh-open-with

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Management panel: Settings → Plugins.
 
 - [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) - VS Code chat windows backed by the DSH agent: OpenCode-style independent sessions, model auto-routing (Flash/Pro/Pro Max).
 - [dsh-plugin-open-editor](https://github.com/Civitasv/dsh-plugin-open-editor) - Open the current workspace in your local editor (VS Code, Cursor, JetBrains, Vim, ...) from the session header.
+- [dsh-open-with](https://github.com/ChuanTianML/dsh-open-with) - Open registered DSH workspaces from the Web UI in detected or configured local editors, terminals, or file managers, with a remembered per-browser preference.
 - [DSH-for-VSC](https://github.com/yauntyour/DSH-for-VSC) - VS Code extension embedding the DSH WebUI as an editor panel: sidebar console with service status and start/stop, hidden auto-restart, status-bar indicator and run logs.
 - [dsh-gui](https://github.com/xuboboo/dsh-gui) - Third-party Windows desktop client for DeepSeek Harness: native window, branded theme & splash, startup crash fixes, token usage statistics.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -223,6 +223,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh4vscode](https://github.com/DoggyHU/dsh4vscode) - 基于 DSH agent 的 VS Code 聊天窗口：OpenCode 式独立会话、模型自动路由（Flash/Pro/Pro Max）。
 - [dsh-plugin-open-editor](https://github.com/Civitasv/dsh-plugin-open-editor) - 从会话页头一键用本地编辑器（VS Code / Cursor / JetBrains / Vim 等）打开当前项目。
+- [dsh-open-with](https://github.com/ChuanTianML/dsh-open-with) - 从 DSH Web UI 使用自动检测或手动配置的本机编辑器、终端或文件管理器打开已登记工作区，并按浏览器记住首选目标。
 - [DSH-for-VSC](https://github.com/yauntyour/DSH-for-VSC) - 把 DSH 的 WebUI 搬进 VS Code：编辑器内嵌面板 + 侧边栏控制台（服务状态/一键启停），离线自动拉起、日志随时可查、状态栏常驻指示。
 - [dsh-gui](https://github.com/xuboboo/dsh-gui) - DeepSeek Harness 第三方 Windows 桌面客户端：原生窗口、品牌主题与启动动画、启动崩溃修复、Token 用量统计。
 

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -84,6 +84,9 @@ EXTRA_TOPIC_REPOS = [
     {"full_name": "xuboboo/dsh-gui", "name": "dsh-gui",
      "html_url": "https://github.com/xuboboo/dsh-gui",
      "description": "DeepSeek Harness 第三方 Windows 桌面客户端：原生窗口、品牌主题与启动动画、启动崩溃修复、Token 用量统计"},
+    {"full_name": "ChuanTianML/dsh-open-with", "name": "dsh-open-with",
+     "html_url": "https://github.com/ChuanTianML/dsh-open-with",
+     "description": "从 DSH Web UI 的已登记工作区列表中，使用自动检测或手动配置的本机编辑器、终端或文件管理器打开目录，并记住浏览器首选目标"},
 ]
 
 


### PR DESCRIPTION
## Summary

- Add `ChuanTianML/dsh-open-with` to **IDE & Clients** in the English and Chinese curated lists.
- Describe the actual surface: the registered-workspace row in DSH Web, with detected or configured editors, terminals, and file managers.
- Add a catalog fallback entry so the repository remains discoverable when it falls beyond GitHub Search's 1,000-result cap.

This complements `dsh-plugin-open-editor`: that entry opens the current workspace from the session header, while `dsh-open-with` acts on registered workspaces and remembers the selected target per browser.

## Discovery context

An exact GitHub topic search already returns the repository for `topic:dsh-plugin`, but the broad topic currently has more than 1,000 results. The catalog generator reads only the first ten 100-item pages, so a new low-star repository can be omitted even when its topic is correct. The existing `EXTRA_TOPIC_REPOS` mechanism is intended for this case and now includes `dsh-open-with`.

The current `deepseekdocs.com/ecosystem` payload was fetched at `2026-08-15T04:47:40Z` and does not contain the repository. After this PR is merged and the catalog is refreshed, the explicit fallback prevents the same omission.

## Demo

![Choose a local target from a registered DSH workspace](https://github.com/ChuanTianML/dsh-open-with/blob/open-with-assets/workspace-editor-chooser.gif?raw=true)

## Verification

- `git diff --check`
- End-to-end catalog generation with an empty topic result: the fallback emits `ChuanTianML/dsh-open-with` under `开发与工程`
- `npx --yes awesome-lint@latest README.md` reports the repository's existing topic/list errors and no issue on the added entry
- `package.json` declares `dsh.bundle.patch`
- GitHub repository is public, active, and tagged `dsh-plugin`
- Fresh install of the `v0.1.1` tag was verified as `dsh-open-with 0.1.1`

The contribution guide specifies no test suite for Markdown entries.
