### PR TITLE
docs: add dsh-timeline-studio-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,8 @@ Management panel: Settings → Plugins.
 
 - [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - Turn a DeepSeek Harness session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts.
 
+- [dsh-timeline-studio-plugin](https://github.com/MartinDelophy/dsh-timeline-studio-plugin) - Connects DSH to Timeline Studio for `.timeline` project inspection, semantic edit previews, transactional edits, and verified MP4 rendering.
+
 
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - Export the append-only session log as human-readable Markdown or HTML, grouped by trajectory source.
 - [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) - Bundled Xiaohongshu/RED viral-note agent skill: hot-note research, note generation/rewrite, verification, authorized account analysis, QR login and controlled publishing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -346,6 +346,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [folio](https://github.com/nyantused-cpun/folio) - Folio（兰亭）：咨询文档生成引擎（接案 → 记忆 → 方法论 → 交付物 → 凭证）的原生 DSH 插件栈：15 个工具、会话协议事件、L0 防护、Agent 预设；方法论包可替换，DSH 内零密钥起步。
 - [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - 把 DeepSeek Harness 会话一键变成工作日报/周报/交接文档/公众号文章，附可验证凭据（报告与产物哈希）。
 
+- [dsh-timeline-studio-plugin](https://github.com/MartinDelophy/dsh-timeline-studio-plugin) - 将 DSH 接入 Timeline Studio，可检查 `.timeline` 工程、预演语义编辑、事务式写入，并验证 MP4 渲染结果。
+
 
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - 把 append-only 会话日志导出为人可读的 Markdown/HTML，按轨迹来源（系统提示/思维链/工具调用/子 agent）分组。
 - [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) - 小红书爆款笔记 agent skill 插件：热门笔记研究、选题、种草文案生成/改写、合规校验、授权账号权重分析、扫码登录与受控发布。


### PR DESCRIPTION
## What changed

- Adds `dsh-timeline-studio-plugin` to Output & Deliverables.
- Updates both English and Simplified Chinese lists with matching factual descriptions.

## Why

The project is a public DSH bundle that connects DeepSeek Harness to Timeline Studio for deterministic `.timeline` project inspection, semantic edit previews, transactional edits, and verified MP4 rendering.

## Validation

- Repository carries the `dsh-plugin`, `dsh`, and `deepseek-harness` topics.
- Bundle installation and final Cordis composition were verified with DSH `0.1.0-rc.6`.
- Plugin checks pass: 8 unit/manifest tests and 1 end-to-end Timeline Studio workflow.
- `git diff --check` passes for this documentation change.

