### PR TITLE
docs: add dsh-digipet (Fun & Lifestyle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ Management panel: Settings → Plugins.
 - [dsh-tavern-plugin](https://github.com/dsh-external/dsh-tavern-plugin) - Tavern character cards.
 - [dsh-sfw](https://github.com/dsh-external/dsh-sfw) - Safety filter.
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - Custom status labels for the whale's deep-diving (cordis).
+- [dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising pet: hatches from an egg, feeds on real work (turns, tools, errors), and evolves along four lines shaped by how you work; zero tokens, command-only.
 
 ## Infrastructure & Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -346,6 +346,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-tavern-plugin](https://github.com/dsh-external/dsh-tavern-plugin) - 小酒馆角色卡
 - [dsh-sfw](https://github.com/dsh-external/dsh-sfw) - 安全过滤
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - 鲸鱼娘思考状态自定义标签（cordis）
+- [dsh-digipet](https://github.com/swaylq/dsh-digipet) - 数码宝贝式养成宠物：孵蛋、吃真实工作长大（回合、工具、报错都算营养），按工作方式走四条进化路线；零 token、纯命令交互。
 
 ## Infrastructure & Development
 


### PR DESCRIPTION
Adds **dsh-digipet** to Fun & Lifestyle in both `README.md` and `README.zh-CN.md`.

One-line case for curation: the list's pet slot (dsh-clippy) is a state-reactive companion; dsh-digipet is the ecosystem's first hatch-and-evolve raising game — an egg fed by real work (turns, tool calls, errors) that evolves through the full classic stage chain (Egg → Baby Ⅰ → Baby Ⅱ → Child → Adult → Perfect → Ultimate) across a 22-slot dex, four lineages chosen by which stat dominated the stage, plus a hidden care-mistake line (stuffed-belly evolutions end badly, as tradition demands). Zero model-facing surface (no tool, no injection — four notification-mode event taps + one command), so it costs zero tokens per request.

Factual notes: verified on dsh `0.1.0-rc.6` end-to-end (install, boot, command dispatch, real-event feeding, hatch ceremony, cross-restart save migration); 42 unit/integration tests; pure JS, zero dependencies; MIT; `dsh-plugin`/`dsh` topics tagged. Entries follow the bare-name ` - ` format, no badges, both language files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
