### PR TITLE
docs: add ciceroyang/dsh-plugin-starter and ciceroyang/dsh-doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,8 @@ Management panel: Settings → Plugins.
 
 ## Infrastructure & Development
 
+- [dsh-plugin-starter](https://github.com/ciceroyang/dsh-plugin-starter) - Scaffold a battle-tested DSH plugin (bundle, tool, runtime skill, tests, CI) in one command, zero dependencies.
+- [dsh-doctor](https://github.com/ciceroyang/dsh-doctor) - One-command local environment health check for DSH: node/pnpm/dsh versions, port 3080, DSH_HOME writability, profile manifests, session logs, zstd.
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH in one command: skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate, a migration diff report, and a movein_from_claude_code agent tool.
 - [dsh-observation-journal](https://github.com/Cavan-Ou/dsh-observation-journal) - Zero-touch runtime telemetry for DSH: every session auto-writes task, model tier, tools, failures, duration, status into a human-readable journal with a stats section (pure observer — no tools, no LLM calls, no injection).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -349,6 +349,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Infrastructure & Development
 
+- [dsh-plugin-starter](https://github.com/ciceroyang/dsh-plugin-starter) - 一条命令生成实战验证过的 DSH 插件工程（bundle、工具、运行时 skill、单测、CI），零依赖免构建。
+- [dsh-doctor](https://github.com/ciceroyang/dsh-doctor) - DeepSeek Harness 本地环境一键体检：node/pnpm/dsh 版本、端口 3080、DSH_HOME 可写性、profile 清单、会话日志、zstd。
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [dsh-movein](https://github.com/sjh9714/dsh-movein) - 一条命令把整套 Claude Code 配置迁入 DSH：技能、MCP 服务器、hooks、子代理与权限规则，附 dry-run 迁移清单、迁移差异报告与 movein_from_claude_code 工具。
 - [dsh-observation-journal](https://github.com/Cavan-Ou/dsh-observation-journal) - 把 DeepSeek Harness 的零侵入运行事实遥测：每个会话自动把任务/模型档位/工具/失败/时长/状态写入人机共读观测卡并附统计区（纯观察者——零工具、零 LLM、零注入）。


### PR DESCRIPTION
Two community developer tools under Infrastructure & Development (both languages):

1. **dsh-plugin-starter** — zero-dependency scaffold generating a battle-tested DSH plugin project (host plugin + tool + runtime skill + node:test suite + four-node CI + bundle manifest), encoding pitfalls from the dsh-report-studio tutorial. Renamed from create-dsh-plugin to avoid collision with dsh-suite's package.
2. **dsh-doctor** — one-command local environment health check (node/pnpm/dsh versions, port 3080, DSH_HOME writability, profile manifests, session logs, zstd), implementing the community request in deepseek-harness Discussions #1719.

- Repos: https://github.com/ciceroyang/dsh-plugin-starter / https://github.com/ciceroyang/dsh-doctor
- Topic: dsh-plugin
- Tests: 5/5 and 7/7; CI green on Node 18/20/22/24