### PR TITLE
docs: add AbnerAI/dsh-monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ Management panel: Settings → Plugins.
 - [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) - Team collaboration (cordis).
 
 - [plugin-notify](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify) - IM webhook + local notifications on turn completion / errors / approval requests (Feishu, WeCom, DingTalk, Slack, Discord, custom).
+- [dsh-monitor](https://github.com/AbnerAI/dsh-monitor) - Persistent background watchers (file inbox / command output) that wake the agent on new messages; the harness analog of Claude Code's Monitor tool.
 
 ## Fun & Lifestyle
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -326,6 +326,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) - 团队协作（cordis）
 
 - [plugin-notify](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify) - 回合完成/出错/需审批时发 IM webhook 与本机通知（飞书/企微/钉钉/Slack/Discord/自定义）。
+- [dsh-monitor](https://github.com/AbnerAI/dsh-monitor) - 常驻后台监视器（文件收件箱/命令输出）：新消息一到即唤醒 Agent，是 Claude Code Monitor 工具的 Harness 对应实现。
 
 ## Fun & Lifestyle
 


### PR DESCRIPTION
### What

Add [**AbnerAI/dsh-monitor**](https://github.com/AbnerAI/dsh-monitor) to the **Notifications & Channels** category in both `README.md` and `README.zh-CN.md`.

### About the plugin

`dsh-monitor` arms persistent background watchers (append-only NDJSON file inbox or shell command output delta). When new content arrives it wakes the owning agent — the harness analog of Claude Code's `Monitor` tool and `<task-notification>` mechanism.

### Compliance

- ✅ Declares `dsh.bundle` manifest in `package.json` (with `cordis.patch.yml`) — installable via `dsh plugin add`
- ✅ Real working code, MIT license
- ✅ `dsh-plugin` topic added

### Install

```
dsh plugin --profile web add dsh-monitor
```