### PR TITLE
docs: add flyingtimes/dsh-trajectory-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Management panel: Settings → Plugins.
 - [dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) - Theme studio for the DSH Web GUI: five built-in presets plus fully customizable light/dark palettes (accent, background, foreground, UI and code fonts, translucent sidebar, contrast), hot-swapped instantly and persisted in localStorage.
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) - OpenCodeGo quota monitor for the DSH Web GUI: a breathing indicator at the input's bottom-right (green/yellow/red by remaining share), a liquid-glass panel with rolling/weekly/monthly usage windows and reset times, auto-refreshing every 30 s; API key read from DSH credentials.
 - [dsh-smooth-stream](https://github.com/SpookySandwich/dsh-smooth-stream) - Better streaming text animation for DeepSeek Harness.
+- [dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) - A 轨迹解读 (trajectory interpretation) tab that summarizes each user round — what was wanted, how the assistant thought and executed, files/commands/errors — via a rules engine plus optional LLM narrative; user messages stay verbatim.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -218,6 +218,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-theme-plugin](https://github.com/BeiZi6/dsh-theme-plugin) - DSH Web GUI 主题工作室：5 套内置预设 + 完全可自定义的浅/深配色（强调色、背景、前景、UI 与代码字体、半透明侧栏、对比度），即时热切换并持久化到 localStorage。
 - [dsh-opencodego-usage](https://github.com/BeiZi6/dsh-opencodego-usage) - OpenCodeGo 剩余额度监视器：输入框右下角呼吸指示灯（按剩余额度绿/黄/红），液态玻璃面板显示滚动/周/月用量窗口与重置时间，每 30 秒自动刷新；API Key 自动读取 DSH 凭据。
 - [dsh-smooth-stream](https://github.com/SpookySandwich/dsh-smooth-stream) - 给 DeepSeek Harness 加入更好的流式文字动画。
+- [dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) - 轨迹解读标签页：按用户轮次逐轮解读助手做了什么（需求/思路/执行/结果，规则引擎 + 可选 LLM 叙述），涉及文件、命令与错误一目了然，用户消息原样保留。
 
 ## IDE & Clients
 


### PR DESCRIPTION
## What

Adds [dsh-trajectory-reader](https://github.com/flyingtimes/dsh-trajectory-reader) to **UI & Experience** (both language versions, per the contributing guide).

- A DeepSeek Harness web client plugin that adds a 「轨迹解读」(trajectory interpretation) tab beside 对话/轨迹: per user round it summarizes what the user wanted and how the assistant fulfilled it (需求/思路/执行/结果) with a rules-based engine plus optional LLM narrative; files, commands and errors at a glance; user messages stay verbatim.
- Install: `dsh plugin --profile web add @clarkchan/trajectory-reader` (declares `dsh.bundle.patch`, activates automatically) — also on npm.
- Entry format follows the standard: repo link + one-line factual description, updated in README.md and README.zh-CN.md in the same PR.