### PR TITLE
docs: add upstream-radar

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Management panel: Settings → Plugins.
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - Interpreter plugin (cordis).
 - [dsh-notebooks](https://github.com/dsh-external/dsh-notebooks) - Notebooks plugin (cordis).
 - [dsh-plugin-radar](https://github.com/dsh-external/dsh-plugin-radar) - Daily DSH plugin compatibility radar, renamed from dsh-external-research.
+- [MicroMilo/upstream-radar](https://github.com/MicroMilo/upstream-radar) - Always-on dependency security monitoring for DSH plugins: exact installed paths, OSV vulnerabilities, npm releases, and compatibility signals routed to a project-aware DSH Agent.
 - [dsh-scout](https://github.com/dsh-external/dsh-scout) - Scout plugin (cordis).
 - [dsh-share](https://github.com/dsh-external/dsh-share) - Share DSH conversations.
 - [dsh-sonar](https://github.com/dsh-external/dsh-sonar) - Sonar plugin (cordis).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -391,6 +391,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - 解释器插件（cordis）。
 - [dsh-notebooks](https://github.com/dsh-external/dsh-notebooks) - notebooks 插件（cordis）。
 - [dsh-plugin-radar](https://github.com/dsh-external/dsh-plugin-radar) - DSH 插件兼容性雷达，原 dsh-external-research 改名。
+- [MicroMilo/upstream-radar](https://github.com/MicroMilo/upstream-radar) - 面向 DSH 插件的常驻依赖安全监控：追踪实际安装路径、OSV 漏洞、npm 发布与兼容性信号，并路由给了解项目的 DSH Agent。
 - [dsh-scout](https://github.com/dsh-external/dsh-scout) - scout 插件（cordis）。
 - [dsh-share](https://github.com/dsh-external/dsh-share) - DSH 对话分享插件。
 - [dsh-sonar](https://github.com/dsh-external/dsh-sonar) - sonar 插件（cordis）。


### PR DESCRIPTION
## What changed

Add [MicroMilo/upstream-radar](https://github.com/MicroMilo/upstream-radar) to **Infrastructure & Development** in both README files.

## Why it fits

Upstream Radar is an installable DSH bundle published on npm. It monitors the exact installed dependency paths of DSH plugins, matches OSV vulnerabilities, watches npm releases, emits compatibility signals, and routes project evidence to a DSH Agent.

The entry is one line per language and uses a factual, non-promotional description as requested by the contribution guide.
