### PR TITLE
Add dsh-wildmon (Pokemon-style catch-em-all, zero tokens)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Management panel: Settings → Plugins.
 - [dsh-sfw](https://github.com/dsh-external/dsh-sfw) - Safety filter.
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - Custom status labels for the whale's deep-diving (cordis).
 - [dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising pet: hatches from an egg, feeds on real work (turns, tools, errors), and evolves along four lines shaped by how you work; zero tokens, command-only.
+- [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - Pokemon-style catch-em-all: turns, tools and errors spawn wild encounters; throw balls, fill a 28-slot dex, team of six; zero tokens, command-only.
 
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -375,6 +375,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-sfw](https://github.com/dsh-external/dsh-sfw) - 安全过滤
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - 鲸鱼娘思考状态自定义标签（cordis）
 - [dsh-digipet](https://github.com/swaylq/dsh-digipet) - 数码宝贝式养成宠物：孵蛋、吃真实工作长大（回合、工具、报错都算营养），按工作方式走四条进化路线；零 token、纯命令交互。
+- [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - 宝可梦式捕捉收集：回合、工具、报错刷出野外遭遇，投球捕捉、集 28 格图鉴、组 6 只队伍；零 token、纯命令交互。
 
 
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。


### PR DESCRIPTION
Adds **dsh-wildmon** to *Fun & Lifestyle*, right after its sibling dsh-digipet.

**What it is**: the collect-em-all loop (encounter → catch → dex collection → team of six) mounted on real harness work — turns, tool calls and errors roll wild encounters (errors loudest; 00:00–05:59 wakes a night pool), balls get thrown, a 28-slot dex fills up. Zero tokens, zero tools, no model-facing surface; every listener is try/catch-wrapped and it only writes its own save file.

**Why it's not a duplicate**: the pet lane has state mirrors (whale-girl, Clippy, …) and one raising game (dsh-digipet). Collecting was empty — pokemon / pokedex / catching / gacha give zero hits in the `dsh-plugin` topic (2,800+ repos) and the curated lists as of 2026-08. wildmon and digipet are complementary (breadth vs depth) and install side by side.

**Verified** on dsh `0.1.0-rc.6` (macOS, web profile): `dsh plugin --profile web add github:swaylq/dsh-wildmon` installs (pure JS, zero deps, no `prepare` script), boots clean, and the full encounter → throw → catch → dex flow was driven in a real browser, with the save file reconciling line by line against observed events. 61 unit/integration tests.

**IP note**: all 28 species names, ASCII art and copy are original; no franchise names or assets (see the README's "Homage and boundaries" section).

- [x] Repo tagged with `dsh` / `dsh-plugin` / `deepseek-harness` / `cordis` / `ai-agents` topics
- [x] Both `README.md` and `README.zh-CN.md` updated in this PR
- [x] MIT licensed
