### PR TITLE
Add dsh-continual-evolve to Context & Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ Management panel: Settings → Plugins.
 
 
 - [moguiyu/dsh-tavily](https://github.com/moguiyu/dsh-tavily) - Tavily search with multiple API keys, key rotation/failover, usage gauge, and a settings card for DSH.
+- [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories.
+
 ## Input & Editing
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.


### PR DESCRIPTION
Adds [ZK-Andy/dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) — a Continual self-evolution plugin for DeepSeek Harness: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories, with review gates and hot-reloaded skills.

- Declares `dsh.bundle` in package.json → installable via `dsh plugin add dsh-continual-evolve`
- Published on npm (dsh-continual-evolve@0.1.0), MIT license
- Has the `dsh-plugin` GitHub topic