### PR TITLE
docs: add dsh-wildmon (Fun & Lifestyle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Management panel: Settings → Plugins.
 - [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - Pokemon-style catch-em-all: turns, tools and errors spawn wild encounters; throw balls, fill a 28-slot dex, team of six; zero tokens, command-only.
 
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.
+- [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - Collect-em-all safari: work rustles the grass — wild encounters, ball throws, a 28-slot dex, a team of six; zero tokens, command-only.
 
 ## Infrastructure & Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -386,6 +386,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
+- [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - 宝可梦式收集猎游：工作惊动草丛 —— 野生遭遇、扔球捕捉、28 格图鉴、6 只队伍；零 token、纯命令交互。
 
 ## Infrastructure & Development
 


### PR DESCRIPTION
Adds **dsh-wildmon** to Fun & Lifestyle in both `README.md` and `README.zh-CN.md`.

One-line case for curation: alongside the state-reactive pets and dsh-digipet's raising game, **collecting** was the remaining empty slot — dsh-wildmon mounts the full collect-em-all loop (encounter → catch → dex → team) on real harness work: turns/tools/errors rustle the grass with a pity mechanic, rarity-scaled catches, five habitats routed by what you were actually doing, nocturnal species, three conditional legendaries, 1/64 shinies. Zero model-facing surface (four notification-mode event taps + one command), zero tokens per request.

Factual notes: verified on dsh `0.1.0-rc.6` end-to-end (install, boot, starter pick, real-event encounter spawn, miss-then-catch reconciled line by line against the save); 61 unit/integration tests; pure JS, zero dependencies; MIT; `dsh-plugin`/`dsh` topics tagged. All 28 species names/art are original; the trademark boundary is stated in the README. Entries follow the bare-name ` - ` format, no badges, both language files in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
