### PR TITLE
docs: add dsh-token-pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Management panel: Settings → Plugins.
 
 ## UI & Experience
 
+- [dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) - Cute token-usage pet in the session header: live context occupancy, per-session usage and breakdown, plus date/weekday, weather, 3-day forecast and severe-weather alerts, all theme-aware.
 - [dsh-office](https://github.com/Fayelin12/dsh-office) - Office workspace & session dashboard: a floating 6-column sprite panel visualizing workspaces, sessions, token usage and subagents.
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - Keyboard-first command palette for DeepSeek Harness Web.
 - [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) - Pins off-screen expanded Think/tool/command labels to the top of the DSH Web conversation and collapses every expanded section in one click (custom hotkey).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -164,6 +164,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## UI & Experience
 
+- [dsh-token-pet](https://github.com/pk7j7sqryy-ops/dsh-token-pet) - 会话头部卡通用量小部件：实时上下文占用、会话累计与构成，附日期周几、天气、3 天预报与极端天气预警，跟随主题色。
 - [dsh-office](https://github.com/Fayelin12/dsh-office) - 办公室工作区/会话仪表盘：悬浮 6 列精灵面板，可视化工作区、会话、token 用量与子代理。
 - [dsh-spotlight](https://github.com/0xsline/dsh-spotlight) - DeepSeek Harness Web 的键盘优先命令面板。
 - [dsh-sticky-disclosure](https://github.com/Han-1413141/dsh-sticky-disclosure) - 将滑出屏幕的 Think/工具/命令标签钉在 DSH Web 会话顶部，并支持一键收起所有展开区块与自定义快捷键。


### PR DESCRIPTION
Add `dsh-token-pet` — a cute token-usage pet widget for DeepSeek Harness.

- Live context occupancy (progress bar), per-session token usage and context breakdown — reuses host token-meter projections (zero extra requests).
- Date/weekday, realtime weather, 3-day forecast, and severe-weather alerts (rain/snow particles).
- Theme-aware (light/dark), embedded in the session header.
- Dynamic Cordis plugin (Host + Client), MIT licensed.

Repo: https://github.com/pk7j7sqryy-ops/dsh-token-pet