### PR TITLE
Add awesome-dsh to Infrastructure & Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Management panel: Settings → Plugins.
 - [dsh-chat-tools](https://github.com/yj060464-commits/dsh-chat-tools) - Headless terminal companion toolkit: chat.sh continuous-conversation REPL (rolling context, decision-point voting, live workflow streaming, effort switching) + automatic LLM session-log summarization. Zero-dependency bash + Python.
 
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - Plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and community pitfalls.
+- [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - Auto-updating catalog of the whole `dsh-plugin` topic (2600+ repos): a Cloudflare Worker recrawls every 6 hours, translates English descriptions to Chinese with Workers AI, and serves a ranked search API plus an agent skill that finds and installs plugins on demand.
 
 ## Data & Market
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -445,6 +445,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-chat-tools](https://github.com/yj060464-commits/dsh-chat-tools) - headless 终端伴侣工具链：chat.sh 连续对话 REPL（滚动上下文/决策点拍板/工作流实时透传/思考档位切换）+ 会话日志 LLM 自动总结，零依赖纯 bash+Python
 
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - 插件开发知识库，作为按需加载的智能体技能：官方约束、任务工作流、API 参考与社区踩坑。
+- [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - `dsh-plugin` topic 全量目录，自动更新（2600+ 仓库）：Cloudflare Worker 每 6 小时重新抓取，用 Workers AI 把英文简介译成中文，并提供相关度检索 API 与按需查找、安装插件的智能体技能。
 
 ## Data & Market
 


### PR DESCRIPTION
Adds [awesome-dsh](https://github.com/stakeswky/awesome-dsh) under **Infrastructure & Development** (the category description lists "catalogs").

A Cloudflare Worker that keeps a full catalog of the `dsh-plugin` topic:

- Crawls the **whole** topic (2652 of 2683 repos at the time of writing), partitioning by star range so it is not capped by the GitHub Search API's 1000-results-per-query limit.
- Translates English descriptions to Chinese with Workers AI, cached per source-text fingerprint.
- Serves a ranked search API (`/api/search`) so agents can pick a plugin without downloading the 1.1 MB catalog.
- Ships a Claude Code skill that turns a user's need into a search and then the real `dsh plugin add` command.

Live at <https://dsh.jamintextiles.com>. Source is MIT.

Both `README.md` and `README.zh-CN.md` are updated in this PR, per contributing.md.