### PR TITLE
docs: add DshCockpit

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,7 @@ Management panel: Settings → Plugins.
 - [dsh-gui](https://github.com/xuboboo/dsh-gui) - Third-party Windows desktop client for DeepSeek Harness: native window, branded theme & splash, startup crash fixes, token usage statistics.
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - Cross-platform Rust/Tauri desktop shell that supervises `dsh web`, reclaims process trees, selects free ports, and publishes Windows/Linux/macOS installers without forking the upstream UI.
 - [DSH Deck](https://github.com/Socialist-Sister/dsh-deck) - Unofficial Electron desktop shell for the official DSH Web UI (same code, same data): attach-to-existing-harness mode prevents dual-writer session corruption, session-log relocated to the session row menu, tray residency, single portable exe.
+- [DshCockpit](https://github.com/Lxiayu/DshCockpit) - Electron desktop cockpit for `dsh web`: tray-resident background tasks, token/cost tracking with budget alarms, runtime auto-update with rollback, Quick Ask hotkey, scheduled tasks, full-text session search.
 
 ## Browser & Remote
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,6 +249,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-gui](https://github.com/xuboboo/dsh-gui) - DeepSeek Harness 第三方 Windows 桌面客户端：原生窗口、品牌主题与启动动画、启动崩溃修复、Token 用量统计。
 - [DSH Studio](https://github.com/Moresyl/dsh-studio) - 跨平台 Rust/Tauri 桌面外壳：托管 `dsh web`、回收进程树、自动选择空闲端口，并发布 Windows/Linux/macOS 安装包，无需 fork 上游 UI。
 - [DSH Deck](https://github.com/Socialist-Sister/dsh-deck) - 非官方 Electron 桌面外壳：复用官方 DSH Web UI 与数据，支持附加到现有 Harness、防止双写会话损坏、托盘常驻与单文件便携版。
+- [DshCockpit](https://github.com/Lxiayu/DshCockpit) - Electron 桌面驾驶舱：托盘常驻后台任务、Token 用量与成本统计（预算报警）、运行时自动更新与回滚、Quick Ask 全局热键、定时任务、会话全文检索。
 
 ## Browser & Remote
 


### PR DESCRIPTION
### What

Adds [DshCockpit](https://github.com/Lxiayu/DshCockpit) — an open-source Electron desktop cockpit for DeepSeek Harness (`dsh web`) — to the **IDE & Clients** section.

It's a shell-level companion rather than an in-web plugin, so it complements the existing desktop entries (dsh-gui / DSH Studio / DSH Deck):

- tray-resident background service (closing the window doesn't kill sessions)
- token usage + context-pressure capsule, cost tracking per day/week/month/workspace with budget alarms
- runtime auto-update pipeline with smoke-test guard and one-click rollback
- global-hotkey Quick Ask, scheduled agent tasks, Ctrl+K full-text session search
- plugin marketplace browser for the `dsh-plugin` topic (2,000+ plugins)

Bundled runtime (no Node.js needed); Windows portable + macOS dmg (arm64/x64) via CI releases. MIT.

Both language versions updated in this PR, as required by the contribution guide.