### PR TITLE
docs: add dsh-island (CodeIsland macOS notch bridge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,7 @@ Management panel: Settings → Plugins.
 
 - [plugin-notify](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify) - IM webhook + local notifications on turn completion / errors / approval requests (Feishu, WeCom, DingTalk, Slack, Discord, custom).
 - [dsh-monitor](https://github.com/AbnerAI/dsh-monitor) - Persistent background watchers (file inbox / command output) that wake the agent on new messages; the harness analog of Claude Code's Monitor tool.
+- [dsh-island](https://github.com/cdxiaodong/dsh-island) - Bridge DSH agent sessions, tool calls, and approvals to the CodeIsland macOS notch panel over a Unix socket, with in-panel allow/deny.
 
 ## Fun & Lifestyle
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -373,6 +373,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [plugin-notify](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-notify) - 回合完成/出错/需审批时发 IM webhook 与本机通知（飞书/企微/钉钉/Slack/Discord/自定义）。
 - [dsh-monitor](https://github.com/AbnerAI/dsh-monitor) - 常驻后台监视器（文件收件箱/命令输出）：新消息一到即唤醒 Agent，是 Claude Code Monitor 工具的 Harness 对应实现。
+- [dsh-island](https://github.com/cdxiaodong/dsh-island) - 通过 Unix socket 把 DSH agent 的会话、工具调用与审批实时桥接到 CodeIsland macOS 刘海面板，可直接在面板上批准/拒绝。
 
 ## Fun & Lifestyle
 


### PR DESCRIPTION
Adds **dsh-island** under *Notifications & Channels*: bridges DSH agent sessions, tool calls, and approval requests to the [CodeIsland](https://github.com/wxtsky/CodeIsland) macOS notch panel over a Unix socket, with in-panel allow/deny. Declares a `dsh.bundle` manifest and ships 8 passing tests. Related: https://github.com/wxtsky/CodeIsland/pull/315