### PR TITLE
docs: rename dsh-dashboard to dsh-token-usage-dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Management panel: Settings → Plugins.
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - Pin assistant replies from the Web action strip and recall them into the next model turn (`/pin` `/recall`, with optional wake).
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn navigation plugin.
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - Token usage statistics as a Settings page: cumulative KPIs, a six-month activity heatmap, stacked per-model daily bars and a model donut, rescanned read-only from session logs.
-- [dsh-dashboard](https://github.com/solstice621/dsh_dashboard) - Codex-style token usage dashboard: five stat cards, GitHub-style activity heatmap (daily/weekly views), insights & model ranking; persisted snapshot with incremental sync, survives session deletion.
+- [dsh-token-usage-dashboard](https://github.com/solstice621/dsh-token-usage-dashboard) - Codex-style token usage dashboard: five stat cards, GitHub-style activity heatmap (daily/weekly views), insights & model ranking; persisted snapshot with incremental sync, survives session deletion.
 - [dsh-ultra-ui](https://github.com/dsh-external/dsh-ultra-ui) - Ultra UI plugin (cordis).
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - RMB/USD token billing for the DSH web: official-policy auto pricing (incl. peak/off-peak hours), per-message cost ledger, account balance, locale-driven currency display.
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek account balance and session cost in the DSH Web composer dock (auto-fetched official pricing, peak/off-peak support).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -187,7 +187,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - 在 Web 助手消息操作条钉住回复，再通过 `/pin` `/recall` 召回进下一轮模型上下文（可一键唤醒）。
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn 导航插件。
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - 设置页 Token 用量统计：累计 KPI、半年活跃热力图、按模型堆叠的每日柱状图与模型环形图，只读重算会话日志。
-- [dsh-dashboard](https://github.com/solstice621/dsh_dashboard) - Codex 风格 Token 用量仪表盘：5 张统计卡、GitHub 风格活动热力图（每日/每周视图）、洞察与模型排名；快照持久化 + 增量同步，删除会话后统计保留。
+- [dsh-token-usage-dashboard](https://github.com/solstice621/dsh-token-usage-dashboard) - Codex 风格 Token 用量仪表盘：5 张统计卡、GitHub 风格活动热力图（每日/每周视图）、洞察与模型排名；快照持久化 + 增量同步，删除会话后统计保留。
 - [dsh-ultra-ui](https://github.com/dsh-external/dsh-ultra-ui) - ultra-ui 插件（cordis）。
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - DSH Web 人民币/美元 token 计费插件：官方政策自动计价（含峰谷时段）、逐条消息费用账本、账号余额、按界面语言切换币种。
 - [dsh-balance-meter](https://github.com/Ghost011118/dsh-balance-meter) - DeepSeek 账户余额与当前会话成本显示在 DSH Web 编辑器 dock 中（自动获取官方价格，支持峰时/非峰时计价）。


### PR DESCRIPTION
## Summary

This is a follow-up to the already-merged PR #225. The project has been renamed from `dsh-dashboard` to `dsh-token-usage-dashboard`, so this PR updates the awesome list entry to match the new name and repository URL.

## Why

- The GitHub repository was renamed from `solstice621/dsh_dashboard` to `solstice621/dsh-token-usage-dashboard`.
- PR #225 was merged before the rename, so the current awesome list still shows the old name and old link.
- This keeps the list accurate and prevents users from landing on an outdated repository URL.

## Changes

- `README.md`: update entry name to `dsh-token-usage-dashboard` and link to the new repository.
- `README.zh-CN.md`: update entry name to `dsh-token-usage-dashboard` and link to the new repository.

## About the plugin

`dsh-token-usage-dashboard` is a Codex-style token usage dashboard for DeepSeek Harness Web UI. It provides:

- 5 stat cards: total tokens, peak tokens, longest chat, current streak, longest streak
- GitHub-style activity heatmap with daily/weekly views
- Insights: turns, requests, sessions, active days, cache hit rate, average tokens/duration
- Favorite model ranking (Top 5)
- Persisted snapshot + incremental sync for fast restarts
