### PR TITLE
docs: add loongsuite/dsh-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - Plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and community pitfalls.
 - [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - Auto-updating catalog of the whole `dsh-plugin` topic (2600+ repos): a Cloudflare Worker recrawls every 6 hours, translates English descriptions to Chinese with Workers AI, and serves a ranked search API plus an agent skill that finds and installs plugins on demand.
 - [dsh-guardian](https://github.com/cdxiaodong/dsh-guardian) - Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations.
+- [loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) - OpenTelemetry GenAI tracing for DSH: one span tree per turn (steps, LLM calls with TTFT, tool executions, token usage), exported over standard OTLP to any compatible backend, content capture off by default.
 
 ## Data & Market
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -462,6 +462,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - 插件开发知识库，作为按需加载的智能体技能：官方约束、任务工作流、API 参考与社区踩坑。
 - [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - `dsh-plugin` topic 全量目录，自动更新（2600+ 仓库）：Cloudflare Worker 每 6 小时重新抓取，用 Workers AI 把英文简介译成中文，并提供相关度检索 API 与按需查找、安装插件的智能体技能。
 - [dsh-guardian](https://github.com/cdxiaodong/dsh-guardian) - Agent 安全护栏：拦截并审计所有工具调用，命中敏感操作就要求人工确认。
+- [loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) - DSH 的 OpenTelemetry GenAI 调用链插件：每轮生成一棵 span 树（步骤、带 TTFT 的 LLM 调用、工具执行、token 用量），通过标准 OTLP 上报到任意兼容后端，正文采集默认关闭。
 
 ## Data & Market
 


### PR DESCRIPTION
Adds [loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) to **Infrastructure & Development** in both `README.md` and `README.zh-CN.md`.

It observes DSH's native session, agent-loop, LLM stream, and tool lifecycle and builds one `ENTRY → AGENT → STEP → LLM / TOOL` OpenTelemetry GenAI trace per turn, plus duration and token metrics, exported over standard OTLP/HTTP to Jaeger, Grafana Tempo, SigNoz, Langfuse, or any OTLP backend. It does not claim the harness `sessionTelemetry` seam, so it runs alongside the official OTLP-logs backend, and prompt/response/tool content capture is off by default.

Category choice: `dsh-observation-journal` (runtime telemetry) is already listed there, so that seemed like the closest grouping. Happy to move it if you would rather it sit elsewhere.

Checks against the entry standard:

- Real repository with working code, published to npm as [`@loongsuite/dsh-plugin`](https://www.npmjs.com/package/@loongsuite/dsh-plugin) (`0.1.0-beta.2`, installable with `dsh plugin --profile web add @loongsuite/dsh-plugin`), Apache-2.0, `dsh-plugin` topic present.
- One factual line per language file, no badges or screenshots inside the entry.
- `npx awesome-lint README.md` reports nothing on the added line; the pre-existing 7 warnings and the `awesome-github` error also occur on a clean checkout of `main` in a fork clone.
