### PR TITLE
Add deepDDW: memory + knowledge base + document search for DSH, LAN-wide access

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Management panel: Settings → Plugins.
 - [moguiyu/dsh-tavily](https://github.com/moguiyu/dsh-tavily) - Tavily search with multiple API keys, key rotation/failover, usage gauge, and a settings card for DSH.
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories.
 
+- [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW: memory + knowledge base + document search for DSH, reachable from ANY device on your LAN — built on a production-grade AI platform (team-ready, up to ~20 people).
 ## Input & Editing
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -137,6 +137,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-memory-plugin](https://github.com/volcengine/OpenViking/tree/main/examples/dsh-memory-plugin) - DeepSeek Harness 的 OpenViking 记忆/上下文插件：接入 OpenViking 的自进化上下文数据库，为 dsh 提供跨会话 Agent 记忆与知识 RAG。
 - [moguiyu/dsh-tavily](https://github.com/moguiyu/dsh-tavily) - Tavily 多密钥搜索：支持密钥轮换/故障转移、用量仪表盘与设置卡片。
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - 持续自进化插件：从会话轨迹提炼提示词笔记、记忆、技能与子代理规范，并以版本化、可审计、可回滚的方式维护 Harness 状态。
+- [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW：为 DSH 补齐记忆 + 知识库 + 文档检索，局域网内任意设备（电脑/手机/平板）可访问——封装自企业级 AI 底座平台（团队就绪，支持 20 人以下小团队）。
 ## Input & Editing
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - better-sidebar 的 Office 集成。


### PR DESCRIPTION
## What

Add **deepDDW** to the **Context & Search** category (both English README and README.zh-CN.md):

**deepDDW** — memory + knowledge base + document search for DeepSeek Harness, reachable from ANY device on your LAN.

- Memory write/search via DSH's official MCP interface (streamable-http)
- Knowledge base + document search (SQLite, industry docs/SOPs)
- LAN-wide multi-device access (desktop/laptop/phone/tablet) via gateway proxying
- Built on a production-grade AI platform; team-ready for small businesses (up to ~20 people)
- MIT licensed

## Why Context & Search

The category covers memory & knowledge retrieval — deepDDW's core is exactly that, plus a differentiator no other entry has: **LAN-wide multi-device access** (the official DSH is local-only).

## Checklist

- [x] Real repository: https://github.com/ccch713/deepddw
- [x] One-line description, factual and terse (per contributing.md)
- [x] Both language versions updated in the same PR