### PR TITLE
Add write-chinese-long-screenplay under a new Skills category

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 - [Infrastructure & Development](#infrastructure--development)
 - [Data & Market](#data--market)
 - [Science & Research](#science--research)
+- [Skills](#skills)
 - [Related](#related)
 - [Thanks](#thanks)
 
@@ -487,6 +488,10 @@ Management panel: Settings → Plugins.
 - [dsh-rigorquant](https://github.com/linxichen/dsh-rigorquant) - Agent preset + skill for unattended empirical/computational mathematics research (econ/finance/portfolio): walled multi-agent exploration, dual-track ground-truth derivation, adversarial counterexample-only audit, four-part pre-implementation check battery, and a jacobian/Lean escalation lane.
 - [dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - Complete wuyun-liuqi (five-evolutions-six-qi / 五运六气) Traditional Chinese Medicine skill pack as a DeepSeek Harness Cordis plugin: annual and guest-qi calculation, clinical pattern differentiation, and pathogenesis reasoning.
 - [dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) - Academic writing guard: local-regex linter for revision-process residue, defensive writing and AI-writing tells (em-dash abuse, not-X-but-Y, LLM word spikes, rule of three); writing_audit + writing_rules with incremental auto-audit on paper file writes.
+
+## Skills
+
+- [write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - Chinese long-form screenwriting skill (SKILL.md): two author input blocks (background + character bible) feeding a causal-value engine, anti-AI-flavor review, and a continuity ledger for 100+ scene projects.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,6 +47,7 @@
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Infrastructure & Development](#infrastructure--development)
 - [Data & Market](#data--market)
+- [Skills](#skills)
 - [Related](#related)
 - [Science & Research](#science--research)
 - [Thanks](#thanks)
@@ -482,6 +483,10 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-rigorquant](https://github.com/linxichen/dsh-rigorquant) - 面向实证/计算数学研究（经济/金融/组合）的无人值守 Agent 预设 + 技能：隔离多智能体探索、双轨真值推导、仅反例淘汰的对抗审计、四重实现前校验，以及 jacobian/Lean 升级通道。
 - [dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - 完整 wuyun-liuqi（五运六气）中医运气学技能包，封装为 DeepSeek Harness 插件：年度与客气推算、临床辨证、病机推演。
 - [dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) - 论文写作守卫：本地正则扫描修改过程残留、防御性写作与 AI 写作痕迹（破折号滥用、不是X而是Y、LLM 高频词、三连排比）；writing_audit / writing_rules 工具，论文文件写入后增量自动审计。
+
+## Skills
+
+- [write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - 中文长剧本写作 skill（SKILL.md）：双输入板块（背景 + 人物卡）+ 因果—价值内核，内置去 AI 味审查与连续性台账，支撑 100 场以上长篇幅项目。
 
 ## Related
 


### PR DESCRIPTION
Adds a Chinese long-form screenwriting skill under a new **Skills** category (EN + ZH, per contributing guide "no matching category? propose a new one").

- Repo: [mudden2380078550-creator/write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay)
- What it is: a SKILL.md-format skill (not a bundle) — two author input blocks (background + character bible) feeding a causal-value story engine, anti-AI-flavor review, and a continuity ledger for 100+ scene projects.
- Carries `dsh-plugin` and `dsh` GitHub topics; works on Codex / Claude Code / dsh / zcode.