### PR TITLE
Add cleverer-dsh: execution-discipline plugin suite for DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Management panel: Settings → Plugins.
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
 - [dsh-plans](https://github.com/Optim-Agent/dsh-plans) - Planning-first agent preset: research repository changes into traceable Markdown plans, refine them through reviewer/criticizer subagent rounds, then execute as a DSH goal with a verifier checklist.
 - [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) - Global persistent agent squads with per-agent model/tool policies: manage them in Settings, select and toggle one per conversation, then collaborate on normal sends in a fixed or model-planned order.
+- [cleverer-dsh](https://github.com/Classicoke/cleverer-dsh) - Execution-discipline plugin suite for DSH: anti-stuck failure interception, forced reflection, todo discipline, memory dedup, self-evolving skills (11 plugins + 6 skills, zero dependencies, 426 tests; measured 49% faster and 44% fewer tokens on the same task).
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -90,6 +90,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - 多智能体协同套件：用户可配置的专家名册 + 持久专家实例（可多分身）按需雇佣、星型拓扑追问/中转、团队状态面板、模型对比与多模态视觉桥。
 - [dsh-plans](https://github.com/Optim-Agent/dsh-plans) - 计划先行 Agent 预设：把仓库变更调研沉淀为 dsh-plans/ 下可追溯的 Markdown 计划，经 reviewer/criticizer 子代理多轮打磨，再作为 DSH goal 按验证清单执行。
 - [dsh-agent-team-gui](https://github.com/toolclub/dsh-agent-team-gui) - 全局持久 Agent 小队：每个成员独立配置模型与工具策略；在 Settings 中管理、按对话选择并开关协作，普通发送按固定顺序或由模型规划执行。
+- [cleverer-dsh](https://github.com/Classicoke/cleverer-dsh) - 执行纪律插件套件：死磕拦截（同参重试自动拒绝）、强制反思、任务规划提醒、记忆查重、经验自动沉淀技能（11 插件 + 6 技能，零依赖，426 项测试；同任务实测速度提升 49%、Token 省 44%）。
 
 ## Context & Search
 


### PR DESCRIPTION
Adds [cleverer-dsh](https://github.com/Classicoke/cleverer-dsh) to the **Agents & Orchestration** category (both English and Chinese lists).

**What it is**: an execution-discipline plugin suite for DeepSeek Harness — anti-stuck failure interception (denies identical retries), forced reflection, todo discipline, memory dedup, and self-evolving skills. 11 plugins + 6 skills, zero dependencies, never touches DSH source, 426 unit tests.

**Measured (same real task vs bare DSH)**: 49% faster, 44% fewer estimated tokens, -65% reasoning loops (n=1, direction evidenced).

**Repo hygiene**: `dsh-plugin` topic set; README bilingual (en/zh); install/uninstall one-command.