### PR TITLE
docs: add dsh-notify-win to Notifications & Channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Management panel: Settings → Plugins.
 - [dsh-voice-chat](https://github.com/dsh-external/dsh-voice-chat) - Voice chat.
 - [dsh-web-ui-notify](https://github.com/dsh-external/dsh-web-ui-notify) - WebUI notifications.
 - [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) - Windows notifications, zero dependencies.
+- [dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) - Native Windows toast + taskbar flash for task done / approval / ask_user_question; Win10/11, npm install `dsh plugin --profile web add dsh-notify-win`.
 - [dsh-ica](https://github.com/dsh-external/dsh-ica) - ICalingua frontend.
 - [dsh-opencode-server](https://github.com/dsh-external/dsh-opencode-server) - Smooth TUI via opencode attach.
 - [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) - Team collaboration (cordis).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -388,6 +388,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-voice-chat](https://github.com/dsh-external/dsh-voice-chat) - 语音对话
 - [dsh-web-ui-notify](https://github.com/dsh-external/dsh-web-ui-notify) - WebUI 通知
 - [dsh-notify-windows](https://github.com/SeverusZh/dsh-notify-windows) - Windows 通知，零依赖
+- [dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) - 原生 Windows toast + 任务栏闪烁，任务完成/审批/提问时触发，支持 Win10/11，npm 安装 `dsh plugin --profile web add dsh-notify-win`
 - [dsh-ica](https://github.com/dsh-external/dsh-ica) - icalingua 前端
 - [dsh-opencode-server](https://github.com/dsh-external/dsh-opencode-server) - opencode attach 丝滑 TUI
 - [dsh-teamwork](https://github.com/dsh-external/dsh-teamwork) - 团队协作（cordis）


### PR DESCRIPTION
Add [dsh-notify-win](https://github.com/Andyqwe44/dsh-notify-win) to Notifications & Channels.

- Native Windows toast + taskbar flash
- Triggers on task done / approval / ask_user_question
- Win10/11
- npm: `dsh plugin --profile web add dsh-notify-win`