### PR TITLE
docs: add dsh-fork-graph

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Management panel: Settings → Plugins.
 - [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) - DeepSeek API balance in a bottom-right floating card on the DSH Web page (auto-refresh + manual refresh).
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - Pin assistant replies from the Web action strip and recall them into the next model turn (`/pin` `/recall`, with optional wake).
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn navigation plugin.
+- [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - Git-style conversation fork graph in the session header: colored lanes and fork curves show which session branched from which, with click-to-jump navigation.
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - Token usage statistics as a Settings page: cumulative KPIs, a six-month activity heatmap, stacked per-model daily bars and a model donut, rescanned read-only from session logs.
 - [dsh-token-usage-dashboard](https://github.com/solstice621/dsh-token-usage-dashboard) - Codex-style token usage dashboard: five stat cards, GitHub-style activity heatmap (daily/weekly views), insights & model ranking; persisted snapshot with incremental sync, survives session deletion.
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - RMB/USD token billing for the DSH web: official-policy auto pricing (incl. peak/off-peak hours), per-message cost ledger, account balance, locale-driven currency display.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -214,6 +214,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-deepseek-quota](https://github.com/yingjunnan/dsh-deepseek-quota) - DSH Web 页面右下角悬浮卡片展示 DeepSeek API 余额（自动刷新 + 手动刷新）。
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - 在 Web 助手消息操作条钉住回复，再通过 `/pin` `/recall` 召回进下一轮模型上下文（可一键唤醒）。
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn 导航插件。
+- [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - 会话标题栏内联的 Git 风格 fork 血缘图：用彩色轨道与分叉曲线显示会话从何处分支，并可点击跳转。
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - 设置页 Token 用量统计：累计 KPI、半年活跃热力图、按模型堆叠的每日柱状图与模型环形图，只读重算会话日志。
 - [dsh-token-usage-dashboard](https://github.com/solstice621/dsh-token-usage-dashboard) - Codex 风格 Token 用量仪表盘：5 张统计卡、GitHub 风格活动热力图（每日/每周视图）、洞察与模型排名；快照持久化 + 增量同步，删除会话后统计保留。
 - [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) - DSH Web 人民币/美元 token 计费插件：官方政策自动计价（含峰谷时段）、逐条消息费用账本、账号余额、按界面语言切换币种。


### PR DESCRIPTION
## Summary

Adds [`dsh-fork-graph`](https://github.com/chouyong/dsh-fork-graph) to the English and Chinese `Dashboards & Session UX` lists. The plugin renders conversation fork lineage as a Git-style graph in the session header: colored lanes and fork curves show which session branched from which, and each node opens that session.

## Genuine screenshots

![Inline session-header trigger](https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-trigger.png)

![Expanded fork graph panel](https://raw.githubusercontent.com/chouyong/dsh-fork-graph/main/assets/screenshot-panel.png)

## Relationship to existing plugins

[`Nirvana-Jie/dsh-session-tree`](https://github.com/Nirvana-Jie/dsh-session-tree) and [`ZhengQingJing/dsh-session-tree`](https://github.com/ZhengQingJing/dsh-session-tree) both use indented trees in the full-tab `conversation.view` slot. `dsh-fork-graph` instead uses Git-style lanes and the inline `conversation.session.header.actions` slot. The slots differ, so the plugins can coexist.

## Verification

- Real DSH `0.1.0-rc.5` Web flow: one completed parent plus two completed sibling forks
- Plugin `client.js`: HTTP 200
- Console errors, page errors, failed requests: 0
- Panel: 2 lanes, 1 fork curve, 3 nodes, current-session highlight
- `npx --yes awesome-lint@latest README.md`: passed; 7 existing-list warnings, none on the new entry