### PR TITLE
docs: add dsh-capability-index

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Management panel: Settings → Plugins.
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - Super-injector (cordis).
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth; tools registered as mcp__<name>__*.
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data, open scoring model, rank/search/recommend tools and a settings-page leaderboard.
+- [dsh-capability-index](https://github.com/777-Zen/dsh-capability-index) - Pre-flight plugin-library check for DSH agents: task-type requests trigger a Top-K hint of suitable plugins with use_when/not_for capability declarations, making plugin usage predictable instead of opportunistic.
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading, and run compare/report.
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) - Living DSH plugin directory (785+ plugins, refreshed hourly) with a daily compatibility CI, a bilingual searchable catalog site, and an in-app plugin store.
 - [create-dsh-plugin](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin) - Scaffold a DSH plugin in seconds (tool / events / webui templates, `next`-tag version pinning, built-in `--verify` smoke test).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -445,6 +445,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - super-injector 插件（cordis）
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP 服务器管理器：设置页添加服务器，OAuth（PKCE + 动态客户端注册）或静态 token 认证，工具注册为 mcp__<name>__*
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
+- [dsh-capability-index](https://github.com/777-Zen/dsh-capability-index) - 插件库起飞前检查单：任务型请求时注入 Top-K 适用插件提示（带作者声明的 use_when/not_for 能力声明），让插件库利用率可预期、不靠运气。
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent 评测平台：benchmark YAML、headless dsh 运行、trace 指标、脚本化评分与 run 对比/报告。
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) - DSH 插件活目录（785+ 插件，每小时刷新）+ 每日兼容性 CI + 中英双语可搜索目录站 + 内置插件商店。
 - [create-dsh-plugin](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin) - 秒建 DSH 插件脚手架（tool/events/webui 模板、锁 `next` 版本、内置 `--verify` 冒烟验证）。


### PR DESCRIPTION
<!-- Thanks for contributing to Awesome DeepSeek Harness! -->

  ## What are you adding?

  - **Name:** dsh-capability-index
  - **Link:** https://github.com/777-Zen/dsh-capability-index
  - **Category:** Plugin Marketplaces & Ecosystem
  - **One-line description:** Pre-flight plugin-library check: injects Top-K hints of suitable plugins with
  use_when/not_for capability declarations on task-type requests.

  ## Checklist

  - [x] The repo carries the `#dsh` GitHub topic
  - [x] I edited **both** `README.md` and `README.zh-CN.md`
  - [x] Entry follows the format: `- [Name](url) — description.`
  - [x] Description is factual and hype-free
  - [x] The project is real, working, and publicly accessible

  ## Notes

  - Meta-plugin: gives DSH agents a pre-flight plugin-library check. On task-type requests it injects a Top-K hint of
  suitable plugins — with the authors' `use_when`/`not_for` capability declarations — into the runtime-context snapshot.
  - Read-only, advisory, zero-invasive. Repo includes a B/C controlled experiment: call rate on non-obvious plugin tools
  went 0% → 100%, zero false triggers (direction-only, small sample); 32 unit tests + offline simulator reproducible.
  - Repo: https://github.com/777-Zen/dsh-capability-index · MIT · tagged `dsh-plugin` and `dsh`.