### PR TITLE
docs: add ciceroyang/dsh-trajectory

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Management panel: Settings → Plugins.
 
 - [folio](https://github.com/nyantused-cpun/folio) - Consulting document-generation engine (intake → memory → methodology → deliverable → proof) as a native DSH plugin stack: 15 tools, session-protocol events, L0 guard, agent preset; swappable methodology packs, zero-key start under DSH.
 - [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - Turn a DeepSeek Harness session into deliverable work reports (daily/weekly/handoff/article) with verifiable receipts; cross-session weekly aggregation and Feishu/Notion publishing.
+- [dsh-trajectory](https://github.com/ciceroyang/dsh-trajectory) - Render a DeepSeek Harness session log into a shareable, self-contained HTML trajectory document (turns, tool calls, token ledger) with a SHA-256 audit stamp.
 - [dsh-timeline-studio-plugin](https://github.com/MartinDelophy/dsh-timeline-studio-plugin) - Connects DSH to Timeline Studio for `.timeline` project inspection, semantic edit previews, transactional edits, and verified MP4 rendering.
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - Export the append-only session log as human-readable Markdown or HTML, grouped by trajectory source.
 - [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) - Bundled Xiaohongshu/RED viral-note agent skill: hot-note research, note generation/rewrite, verification, authorized account analysis, QR login and controlled publishing.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -369,6 +369,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [folio](https://github.com/nyantused-cpun/folio) - Folio（兰亭）：咨询文档生成引擎（接案 → 记忆 → 方法论 → 交付物 → 凭证）的原生 DSH 插件栈：15 个工具、会话协议事件、L0 防护、Agent 预设；方法论包可替换，DSH 内零密钥起步。
 - [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - 把 DeepSeek Harness 会话一键变成工作日报/周报/交接文档/公众号文章，附可验证凭据；支持跨会话聚合周报与飞书/Notion 发布。
+- [dsh-trajectory](https://github.com/ciceroyang/dsh-trajectory) - 把 DeepSeek Harness 会话日志渲染成可分享的自包含 HTML 轨迹文档（回合、工具调用、Token 账本），附 SHA-256 审计戳。
 - [dsh-timeline-studio-plugin](https://github.com/MartinDelophy/dsh-timeline-studio-plugin) - 将 DSH 接入 Timeline Studio，可检查 `.timeline` 工程、预演语义编辑、事务式写入，并验证 MP4 渲染结果。
 - [plugin-session-export](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-session-export) - 把 append-only 会话日志导出为人可读的 Markdown/HTML，按轨迹来源（系统提示/思维链/工具调用/子 agent）分组。
 - [dsh-xiaohongshu-viral-note](https://github.com/xuboboo/dsh-xiaohongshu-viral-note) - 小红书爆款笔记 agent skill 插件：热门笔记研究、选题、种草文案生成/改写、合规校验、授权账号权重分析、扫码登录与受控发布。


### PR DESCRIPTION
Adds dsh-trajectory under Output & Deliverables (both languages).

Zero-dependency ESM CLI that renders a DSH session log (multi-frame zstd) into a shareable, self-contained HTML trajectory document — the offline cousin of the official Trajectory view — with turn timeline, tool calls, token ledger and a SHA-256 audit stamp. 4/4 tests; verified against real session logs (56 turns rendered).