### PR TITLE
add pbr-render: PBR 3D model preview plugin for DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
  <a href="README.md">English</a>&nbsp;&nbsp;|&nbsp;&nbsp;
  <a href="README.zh-CN.md">简体中文</a>
 </p>
@@ -172,6 +172,7 @@ Management panel: Settings → Plugins.
 - [solarized-dsh-theme](https://github.com/zhijun-dai/Solarized-dsh-theme) - Solarized + Selenized theme plugin: four faithful palettes registered into the DSH Web theme runtime.
 - [arcana](https://github.com/GooodWei/arcana) - A floating command deck that lists every slash command in DeepSeek Harness as runnable buttons, sorted by usage.
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC canvas plugin (cordis).
+- [pbr-render](https://github.com/dhb861832993-star/pbr-render) - PBR 3D model preview for game art: GLB/GLTF with textures, IBL environment, orbit controls, and a material channel inspector (baseColor/normal/roughness/metallic/AO/emissive/wireframe) via the pbr3d fence and pbr_render tool.
 - [dsh-deepcel](https://github.com/dsh-external/dsh-deepcel) - Deepcel spreadsheet skin and standalone distribution.
 - [dsh-diff-viewer](https://github.com/dsh-external/dsh-diff-viewer) - PiUI-style Web diff viewer replacing the default diff view.
 - [dsh-mobile](https://github.com/dsh-external/dsh-mobile) - Mobile client plugin (cordis + dsh.plugin.json).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
 	<a href="README.md">English</a>&nbsp;&nbsp;|&nbsp;&nbsp;
 	<a href="README.zh-CN.md">简体中文</a>
 </p>
@@ -171,6 +171,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [solarized-dsh-theme](https://github.com/zhijun-dai/Solarized-dsh-theme) - Solarized + Selenized 主题插件：向 DSH Web 主题运行时注册四套忠实色板。
 - [arcana](https://github.com/GooodWei/arcana) - DeepSeek Harness 的悬浮命令甲板：把所有斜杠命令列成可执行按钮，悬停看介绍，按使用次数排序。
 - [dsh-aigc-canvas](https://github.com/dsh-external/dsh-aigc-canvas) - AIGC 画布插件（cordis）。
+- [pbr-render](https://github.com/dhb861832993-star/pbr-render) - 游戏美术 PBR 3D 模型预览：GLB/GLTF 带贴图纹理、环境光照、轨道控制，以及材质通道检查器（基础色/法线/粗糙度/金属度/AO/自发光/线框），通过 pbr3d 围栏与 pbr_render 工具使用。
 - [dsh-deepcel](https://github.com/dsh-external/dsh-deepcel) - Deepcel 电子表格皮肤与独立分发仓库。
 - [dsh-diff-viewer](https://github.com/dsh-external/dsh-diff-viewer) - PiUI 风格 Web diff 查看器，替换默认 diff 视图。
 - [dsh-mobile](https://github.com/dsh-external/dsh-mobile) - 手机端插件（cordis + dsh.plugin.json）。


### PR DESCRIPTION
Adds [pbr-render](https://github.com/dhb861832993-star/pbr-render) to the UI, Themes & Interaction section.

**pbr-render** is a PBR (physically-based) 3D model preview plugin for DeepSeek Harness: renders GLB/GLTF game art with textures, IBL environment lighting, orbit controls, and a material channel inspector (baseColor/normal/roughness/metallic/AO/emissive/wireframe) via the pbr3d fence and pbr_render tool. Scalar channels (roughness/metallic/AO) display as grayscale per PBR spec.

- Repo topics: dsh, dsh-plugin, pbr, 3d, gltf