### PR TITLE
docs: add dsh-popper

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,7 +451,8 @@ Management panel: Settings → Plugins.
 - [create-dsh-plugin](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/create-dsh-plugin) - Scaffold a DSH plugin in seconds (tool / events / webui templates, `next`-tag version pinning, built-in `--verify` smoke test).
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) - In-app plugin store for the DSH Web UI: browse, search, one-click install, compat badges, installed list.
 - [dsh-genie](https://github.com/swaylq/dsh-genie) - Promote a `cordis_define` dynamic package into a real installed bundle that survives restart; writes the package and registers the profile layer without pnpm, network, or a build authorization.
-- [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - Plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and community pitfalls.
+- [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - Plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and
+- [dsh-popper](https://github.com/1473382/dsh-popper) - Falsification-driven correction loop for agent sessions: risky work commits an evidence-checkable claim first, deterministic gates verify it, falsified claims force mutually exclusive replacement hypotheses with discriminating experiments, and every event lands in an append-only evidence ledger. community pitfalls.
 - [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - Auto-updating catalog of the whole `dsh-plugin` topic (2600+ repos): a Cloudflare Worker recrawls every 6 hours, translates English descriptions to Chinese with Workers AI, and serves a ranked search API plus an agent skill that finds and installs plugins on demand.
 
 ## Runtime & Operations

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -451,6 +451,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [plugin-manager](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-manager) - DSH Web UI 内置插件应用商店：目录浏览/搜索/一键安装/兼容徽章/已装列表。
 - [dsh-genie](https://github.com/swaylq/dsh-genie) - 把 `cordis_define` 的动态包固化为可跨重启存活的正式组合包；写包与注册 profile 层均不需要 pnpm、联网或构建授权。
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - 插件开发知识库，作为按需加载的智能体技能：官方约束、任务工作流、API 参考与社区踩坑。
+- [dsh-popper](https://github.com/1473382/dsh-popper) - 证伪驱动的智能体会话修正循环：高风险操作前先提交可检验主张，确定性 gate 验证结果；主张被证伪后强制给出互斥替代假设并各配判别性实验，全部事件进入只追加的证据账本。
 - [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - `dsh-plugin` topic 全量目录，自动更新（2600+ 仓库）：Cloudflare Worker 每 6 小时重新抓取，用 Workers AI 把英文简介译成中文，并提供相关度检索 API 与按需查找、安装插件的智能体技能。
 
 ## Runtime & Operations


### PR DESCRIPTION
Add [dsh-popper](https://github.com/1473382/dsh-popper) to the curated Plugin Ecosystem & Development section (EN + zh-CN).

**dsh-popper is a DeepSeek Harness plugin** — not an MCP server, not a standalone tool: a cordis-layer correction loop that raises development quality inside the harness by replacing retry-style debugging with enforced falsification (hypothesis → deterministic gate → ≥2 mutually exclusive replacement hypotheses → auditable SHA-256 ledger).

---

> Blind retry is now forced falsify-and-revise, every step recorded in an append-only SHA-256 evidence ledger.
> Popper v0.1 — falsification-driven correction for DeepSeek Harness agents: hypothesis → deterministic gate → ≥2 mutually exclusive replacement hypotheses, no falsified experiment reused.
> 盲目的重试变成强制的「证伪—修订」，每一步都写入只追加的 SHA-256 证据账本。
> Popper 是 DeepSeek Harness 插件（不是 MCP）：一个 cordis 层的证伪驱动校正循环，把重试型调试变成强制证伪与可审计证据。