### PR TITLE
add dsh-hme: tag-indexed cross-session memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Management panel: Settings → Plugins.
 
 ## Memory & Knowledge
 
+- [dsh-hme](https://github.com/weopenfire-git/hme-plugin) - Cross-session long-term memory: bounded core (USER.md global + MEMORY.md per-workspace, φ Fibonacci caps) + a tag-indexed, self-consolidating archive (archive/recall/move tools).
 - [dsh-memory-vault](https://github.com/flymysql/dsh-memory) - Cross-session memory vault: memory_remember / memory_recall / memory_forget tools, latest entries injected into system-prompt assembly, Settings page (记忆库 / Memory).
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) - Memoria memory backend for dsh: 4 tools (observe/remember/search/recall) into a vector+graph memory layer (memoria) with namespace isolation, auto-write (turn-end observe + positive-feedback -> importance-5 remember) and hot-reload settings.
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) - Cross-session long-term memory + background self-evolution (5-track memory/git-branch awareness/skill evolution).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -117,6 +117,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Memory & Knowledge
 
+- [dsh-hme](https://github.com/weopenfire-git/hme-plugin) - 跨会话长期记忆：有界核心（全局 USER.md + 按工作区 MEMORY.md，φ 斐波那契上限）+ 标签索引、自我收敛的档案层（archive/recall/move 三工具）。
 - [dsh-memory-vault](https://github.com/flymysql/dsh-memory) - 跨会话记忆库：memory_remember / memory_recall / memory_forget 三工具，最新条目自动注入系统提示词，设置页（记忆库 / Memory）管理。
 - [dsh-memoria](https://github.com/jiayan-xu/dsh-memoria) - Memoria 记忆后端：为 dsh agent 提供 observe/remember/search/recall 四个工具，支持向量+图记忆、命名空间隔离、自动写入与配置热重载。
 - [dsh-memory-evolve](https://github.com/dsh-external/dsh-memory-evolve) - 跨会话长期记忆 + 后台自我进化（五轨记忆/Git 分支感知/技能进化）


### PR DESCRIPTION
Adds **dsh-hme** to the **Memory & Knowledge** section.\n\nA cross-session long-term memory plugin for DeepSeek Harness:\n- bounded core (USER.md global + MEMORY.md per-workspace, φ Fibonacci caps)\n- tag-indexed, self-consolidating archive (archive/recall/move tools), same-tag writes overwrite\n- pure text, human-editable, no vector DB\n\nRepo: weopenfire-git/hme-plugin (has dsh-plugin topic)\nnpm: @yinging/dsh-hme (0.2.0)