### PR TITLE
docs: enhance deepDDW entry (emoji + license/deploy info)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Management panel: Settings → Plugins.
 - [moguiyu/dsh-tavily](https://github.com/moguiyu/dsh-tavily) - Tavily search with multiple API keys, key rotation/failover, usage gauge, and a settings card for DSH.
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories.
 
-- [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW: memory + knowledge base + document search for DSH, reachable from ANY device on your LAN — built on a production-grade AI platform (team-ready, up to ~20 people).
+- 🌐 [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW: memory + knowledge base + document search for DSH, reachable from ANY device on your LAN — built on a production-grade AI platform (team-ready, up to ~20 people). Apache-2.0, Docker Compose.
 ## Input & Editing
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.


### PR DESCRIPTION
Small enhancement to the existing deepDDW entry: add a 🌐 emoji for visual prominence (consistent with other entries in this list) and append `Apache-2.0, Docker Compose` to surface the license and deployment method.

No other changes.