### PR TITLE
docs: add dsh-safeguard and 13 utility tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@
 - [Plugin Ecosystem & Development](#plugin-ecosystem--development)
 - [Runtime & Operations](#runtime--operations)
 - [Domain & Specialist Skills](#domain--specialist-skills)
+- [Tools & Utilities](#tools--utilities)
 - [Related](#related)
 - [Thanks](#thanks)
 
@@ -365,6 +366,7 @@ Management panel: Settings → Plugins.
 - [MicroMilo/upstream-radar](https://github.com/MicroMilo/upstream-radar) - Always-on dependency security monitoring for DSH plugins: exact installed paths, OSV vulnerabilities, npm releases, and compatibility signals routed to a project-aware DSH Agent.
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - Login gateway for the DSH web UI: first-run setup, bcrypt + at-rest encryption (AES-256-GCM/HMAC), brute-force lockout, audit log, TLS 1.2+ with 80→443 redirect, CSRF and anti-framing headers.
 - [dsh-guardian](https://github.com/cdxiaodong/dsh-guardian) - Agent security guardrail: intercepts and audits every tool call, requiring human confirmation on sensitive operations.
+- [dsh-safeguard](https://github.com/ZhijiangTang/dsh-safeguard) - Pre-execution guardrail: vetoes dangerous shell commands and blocks secret/credential leaks before they run.
 
 ## Output & Deliverables
 
@@ -496,6 +498,22 @@ Management panel: Settings → Plugins.
 - [dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - Complete wuyun-liuqi (five-evolutions-six-qi / 五运六气) Traditional Chinese Medicine skill pack as a DeepSeek Harness Cordis plugin: annual and guest-qi calculation, clinical pattern differentiation, and pathogenesis reasoning.
 - [dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) - Academic writing guard: local-regex linter for revision-process residue, defensive writing and AI-writing tells (em-dash abuse, not-X-but-Y, LLM word spikes, rule of three); writing_audit + writing_rules with incremental auto-audit on paper file writes.
 - [write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - Chinese long-form screenwriting skill (SKILL.md): two author input blocks (background + character bible) feeding a causal-value engine, anti-AI-flavor review, and a continuity ledger for 100+ scene projects.
+
+## Tools & Utilities
+
+- [dsh-case](https://github.com/ZhijiangTang/dsh-case) - Name-case conversion across 8 styles: camel, snake, kebab, Pascal, and more.
+- [dsh-clipboard](https://github.com/ZhijiangTang/dsh-clipboard) - Writes text to the system clipboard, cross-platform (macOS/Windows/Linux).
+- [dsh-cron-parse](https://github.com/ZhijiangTang/dsh-cron-parse) - Parses cron expressions into human-readable text and previews upcoming run times.
+- [dsh-dead-links](https://github.com/ZhijiangTang/dsh-dead-links) - Scans Markdown files for dead http(s) links.
+- [dsh-fetch-file](https://github.com/ZhijiangTang/dsh-fetch-file) - Downloads a URL into the workspace as a file, with a path fence, streaming, and a 200 MB cap.
+- [dsh-fmt](https://github.com/ZhijiangTang/dsh-fmt) - Formats and validates JSON/YAML/TOML/SQL, with line-and-column error locations.
+- [dsh-handoff](https://github.com/ZhijiangTang/dsh-handoff) - Exports the current session as a deterministic Markdown handoff document.
+- [dsh-http](https://github.com/ZhijiangTang/dsh-http) - Structured HTTP request tool: returns status, duration, and size, with basic/bearer auth helpers.
+- [dsh-jwt](https://github.com/ZhijiangTang/dsh-jwt) - Decodes a JWT for debugging without verifying its signature, and flags expiry.
+- [dsh-password](https://github.com/ZhijiangTang/dsh-password) - Generates strong random passwords and diceware passphrases via crypto.
+- [dsh-pkg-info](https://github.com/ZhijiangTang/dsh-pkg-info) - Queries npm/PyPI package metadata (version, license, dependencies).
+- [dsh-url-tools](https://github.com/ZhijiangTang/dsh-url-tools) - URL parsing, tracking-parameter removal, encode/decode, and redirect expansion.
+- [dsh-when](https://github.com/ZhijiangTang/dsh-when) - Parses natural-language relative time (e.g. "in 2 hours") into ISO timestamps, fail-fast.
 
 ## Related
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,6 +51,7 @@
 - [Plugin Ecosystem & Development](#plugin-ecosystem--development)
 - [Runtime & Operations](#runtime--operations)
 - [Domain & Specialist Skills](#domain--specialist-skills)
+- [Tools & Utilities](#tools--utilities)
 - [Related](#related)
 - [致谢](#致谢)
 
@@ -364,6 +365,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [MicroMilo/upstream-radar](https://github.com/MicroMilo/upstream-radar) - 面向 DSH 插件的常驻依赖安全监控：追踪实际安装路径、OSV 漏洞、npm 发布与兼容性信号，并路由给了解项目的 DSH Agent。
 - [dsh-passwords](https://github.com/slywalker2006/dsh-passwords) - DSH Web UI 登录网关：首次配置、bcrypt + 静态加密（AES-256-GCM/HMAC）、防暴力破解、审计日志、TLS 1.2+ 与 80→443 跳转、CSRF 与防嵌框。
 - [dsh-guardian](https://github.com/cdxiaodong/dsh-guardian) - Agent 安全护栏：拦截并审计所有工具调用，命中敏感操作就要求人工确认。
+- [dsh-safeguard](https://github.com/ZhijiangTang/dsh-safeguard) - 执行前护栏：拦截危险 shell 命令与密钥泄漏，阻止其运行。
 
 ## Output & Deliverables
 
@@ -495,6 +497,22 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-wuyun-liuqi](https://github.com/dhicoc/dsh-wuyun-liuqi) - 完整 wuyun-liuqi（五运六气）中医运气学技能包，封装为 DeepSeek Harness 插件：年度与客气推算、临床辨证、病机推演。
 - [dsh-plugin-writing-guard](https://github.com/xmutfyh/dsh-plugin-writing-guard) - 论文写作守卫：本地正则扫描修改过程残留、防御性写作与 AI 写作痕迹（破折号滥用、不是X而是Y、LLM 高频词、三连排比）；writing_audit / writing_rules 工具，论文文件写入后增量自动审计。
 - [write-chinese-long-screenplay](https://github.com/mudden2380078550-creator/write-chinese-long-screenplay) - 中文长剧本写作 skill（SKILL.md）：双输入板块（背景 + 人物卡）+ 因果—价值内核，内置去 AI 味审查与连续性台账，支撑 100 场以上长篇幅项目。
+
+## Tools & Utilities
+
+- [dsh-case](https://github.com/ZhijiangTang/dsh-case) - 命名大小写转换，支持 camel/snake/kebab/Pascal 等 8 种风格。
+- [dsh-clipboard](https://github.com/ZhijiangTang/dsh-clipboard) - 跨平台将文本写入系统剪贴板。
+- [dsh-cron-parse](https://github.com/ZhijiangTang/dsh-cron-parse) - 解析 cron 表达式为人类可读描述，并预览未来运行时间。
+- [dsh-dead-links](https://github.com/ZhijiangTang/dsh-dead-links) - 检查 Markdown 文档中的失效 http(s) 链接。
+- [dsh-fetch-file](https://github.com/ZhijiangTang/dsh-fetch-file) - 将 URL 下载为工作区文件：路径围栏、流式、200MB 上限。
+- [dsh-fmt](https://github.com/ZhijiangTang/dsh-fmt) - JSON/YAML/TOML/SQL 格式化与校验，错误带行列定位。
+- [dsh-handoff](https://github.com/ZhijiangTang/dsh-handoff) - 将当前会话一键导出为确定性 Markdown 交接文档。
+- [dsh-http](https://github.com/ZhijiangTang/dsh-http) - 结构化 HTTP 请求工具：返回状态码、耗时与大小，支持 basic/bearer 认证。
+- [dsh-jwt](https://github.com/ZhijiangTang/dsh-jwt) - 调试用 JWT 解码（不验签），并判断是否过期。
+- [dsh-password](https://github.com/ZhijiangTang/dsh-password) - 基于 crypto 生成强随机密码与 diceware 口令短语。
+- [dsh-pkg-info](https://github.com/ZhijiangTang/dsh-pkg-info) - 查询 npm/PyPI 包信息（版本、许可证、依赖）。
+- [dsh-url-tools](https://github.com/ZhijiangTang/dsh-url-tools) - URL 解析、去跟踪参数、编解码与重定向展开。
+- [dsh-when](https://github.com/ZhijiangTang/dsh-when) - 将自然语言相对时间（如「2 小时后」）解析为 ISO 时间，fail-fast。
 
 ## Related
 


### PR DESCRIPTION
## Summary

Adds 14 utility plugins published under [ZhijiangTang](https://github.com/ZhijiangTang). Each is installable via `dsh plugin add`, published on npm under the same name, tagged [`dsh-plugin`](https://github.com/topics/dsh-plugin), and declares a `dsh.bundle` manifest.

## Placement

- `dsh-safeguard` → **Security & Governance** (pre-execution veto of dangerous shell commands and secret/credential leaks).
- The other 13 → a new **Tools & Utilities** category, proposed here because no existing category covers general agent utility tools (per the contribution guide: "No matching category? Propose a new one in your PR.").

## Entries

| Plugin | What it does |
|---|---|
| `dsh-safeguard` | Pre-execution guardrail: vetoes dangerous shell commands and blocks secret/credential leaks |
| `dsh-http` | Structured HTTP request tool (status / duration / size, basic & bearer auth helpers) |
| `dsh-case` | Name-case conversion across 8 styles (camel / snake / kebab / Pascal …) |
| `dsh-fmt` | Formats + validates JSON / YAML / TOML / SQL, with line & column error locations |
| `dsh-clipboard` | Writes text to the system clipboard, cross-platform |
| `dsh-fetch-file` | Downloads a URL into the workspace as a file (path fence, streaming, 200 MB cap) |
| `dsh-jwt` | JWT decode for debugging (no signature verify), flags expiry |
| `dsh-cron-parse` | Parses cron expressions into human-readable text + next-run preview |
| `dsh-pkg-info` | Queries npm / PyPI package metadata |
| `dsh-dead-links` | Scans Markdown files for dead http(s) links |
| `dsh-when` | Natural-language relative time → ISO timestamps (fail-fast) |
| `dsh-handoff` | Exports the current session as a deterministic Markdown handoff document |
| `dsh-url-tools` | URL parse / tracking-param removal / encode-decode / redirect expansion |
| `dsh-password` | Strong random passwords + diceware passphrases (crypto) |

Both `README.md` and `README.zh-CN.md` are updated with the same entries and translated descriptions, per the contribution guide. Markdown-only change.
