### PR TITLE
docs: add dsh-mcp-skill-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,6 +445,7 @@ Management panel: Settings → Plugins.
 - [dsh-github-integration](https://github.com/dsh-external/dsh-github-integration) - GitHub integration plugin.
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - Super-injector (cordis).
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP server manager: Settings page with OAuth (PKCE + dynamic client registration) or static-token auth; tools registered as mcp__<name>__*.
+- [dsh-mcp-skill-panel](https://github.com/lilyblessing/dsh-mcp-skill-panel) - MCP & Skill manager: real-time enable/disable for MCP servers and skills to free context; optional AI middle layer (mcp_search/mcp_call) with state-based visibility filtering.
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - Transparent plugin rankings and recommendations: daily auto-fetched dsh-plugin topic data, open scoring model, rank/search/recommend tools and a settings-page leaderboard.
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent evaluation platform: benchmark YAML, headless dsh runs, trace-based metrics, scripted grading, and run compare/report.
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) - Living DSH plugin directory (785+ plugins, refreshed hourly) with a daily compatibility CI, a bilingual searchable catalog site, and an in-app plugin store.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -444,6 +444,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-github-integration](https://github.com/dsh-external/dsh-github-integration) - GitHub 集成插件
 - [dsh-super-injector](https://github.com/dsh-external/dsh-super-injector) - super-injector 插件（cordis）
 - [dsh-mcp-manager](https://github.com/hyqhyq3/dsh-mcp-manager) - MCP 服务器管理器：设置页添加服务器，OAuth（PKCE + 动态客户端注册）或静态 token 认证，工具注册为 mcp__<name>__*
+- [dsh-mcp-skill-panel](https://github.com/lilyblessing/dsh-mcp-skill-panel) - MCP 与技能管理面板：MCP 服务器与 Skill 目录实时启停以释放上下文占用；可选 AI 中间层（mcp_search/mcp_call）按 server 状态过滤模型可见性
 - [dsh-recommend](https://github.com/zp-home/dsh-recommend) - 插件透明排行与推荐：每日自动抓取 dsh-plugin 话题生态、公开评分模型，提供榜单/搜索/推荐工具与设置页排行榜。
 - [dsh-eval](https://github.com/hccccc01333/dsh-eval) - Agent 评测平台：benchmark YAML、headless dsh 运行、trace 指标、脚本化评分与 run 对比/报告。
 - [dsh-suite](https://github.com/whyihaveyou/dsh-suite) - DSH 插件活目录（785+ 插件，每小时刷新）+ 每日兼容性 CI + 中英双语可搜索目录站 + 内置插件商店。


### PR DESCRIPTION
Add [dsh-mcp-skill-panel](https://github.com/lilyblessing/dsh-mcp-skill-panel) to the Plugin Ecosystem & Development category (EN + zh-CN). MCP & Skill manager: real-time enable/disable for MCP servers and skills to free context; optional AI middle layer with state-based visibility filtering.