### PR TITLE
docs: add memory-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Management panel: Settings → Plugins.
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - Continual self-evolution: versioned, auditable, rollback-safe harness state (prompt notes, memories, skills, subagent specs) refined from session trajectories.
 - [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW: memory + knowledge base + document search for DSH, reachable from ANY device on your LAN — built on a production-grade AI platform (team-ready, up to ~20 people).
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - Mnemonic layer.
+- [memory-mcp-server](https://github.com/BingoAgentTouch/Personal_MCP) - Layered long-term memory MCP server: raw turns → task fragments → daily summaries → topic indexes, local MiniLM 384-dim embeddings or OpenAI-compatible API backend, semantic + Jaccard-fallback search, one-command DSH plugin install.
 
 ## Input & Editing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -134,6 +134,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-continual-evolve](https://github.com/ZK-Andy/dsh-continual-evolve) - 持续自进化插件：从会话轨迹提炼提示词笔记、记忆、技能与子代理规范，并以版本化、可审计、可回滚的方式维护 Harness 状态。
 - [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW：为 DSH 补齐记忆 + 知识库 + 文档检索，局域网内任意设备（电脑/手机/平板）可访问——封装自企业级 AI 底座平台（团队就绪，支持 20 人以下小团队）。
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - 助记层
+- [memory-mcp-server](https://github.com/BingoAgentTouch/Personal_MCP) - 分层长期记忆 MCP 服务器：原始轮次 → 任务片段 → 每日总结 → 主题索引；本地 MiniLM 384 维嵌入或 OpenAI 兼容 API 后端，语义 + Jaccard 兜底检索，支持 dsh plugin add 一键安装。
 
 ## Input & Editing
 


### PR DESCRIPTION
Adds [memory-mcp-server](https://github.com/BingoAgentTouch/Personal_MCP) to the **Memory & Knowledge** section (README.md + README.zh-CN.md): layered long-term memory MCP server (raw turns ? task fragments ? daily summaries ? topic indexes) with local MiniLM 384-dim embeddings or an OpenAI-compatible API backend, semantic + Jaccard-fallback search; installable as a DSH bundle via `dsh plugin add` (`@bingo_touth/memory-mcp-server`).