### PR TITLE
docs: add dsh-survival

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ Management panel: Settings → Plugins.
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - Custom status labels for the whale's deep-diving (cordis).
 - [dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising pet: hatches from an egg, feeds on real work (turns, tools, errors), and evolves along four lines shaped by how you work; zero tokens, command-only.
 - [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - Pokemon-style catch-em-all: turns, tools and errors spawn wild encounters; throw balls, fill a 28-slot dex, team of six; zero tokens, command-only.
+- [dsh-survival](https://github.com/Socialist-Sister/dsh-survival) - Minecraft-survival game mode as a DSH agent preset: hard-settled HP/hunger/day-night/mobs, vanilla crafting gates and anvil repair, plus a browser status bar; built on the official preset plugin spec.
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.
 
 ## Plugin Ecosystem & Development

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
  <a href="README.md">English</a>&nbsp;&nbsp;|&nbsp;&nbsp;
  <a href="README.zh-CN.md">简体中文</a>
 </p>
@@ -421,7 +421,7 @@ Management panel: Settings → Plugins.
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - Custom status labels for the whale's deep-diving (cordis).
 - [dsh-digipet](https://github.com/swaylq/dsh-digipet) - Digimon-style raising pet: hatches from an egg, feeds on real work (turns, tools, errors), and evolves along four lines shaped by how you work; zero tokens, command-only.
 - [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - Pokemon-style catch-em-all: turns, tools and errors spawn wild encounters; throw balls, fill a 28-slot dex, team of six; zero tokens, command-only.
-- [dsh-survival](https://github.com/Socialist-Sister/dsh-survival) - Minecraft-survival game mode as a DSH agent preset: hard-settled HP/hunger/day-night/mobs, vanilla crafting gates and anvil repair, plus a browser status bar; built on the official preset plugin spec.
+- [dsh-survival](https://github.com/Socialist-Sister/dsh-survival-mode) - Minecraft-survival game mode as a DSH agent preset: hard-settled HP/hunger/day-night/mobs, vanilla crafting gates and anvil repair, plus a browser status bar; built on the official preset plugin spec.
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - A collapsible/expandable draggable floating music player with NetEase Cloud Music playlist import and song/artist search; chat and listen at the same time.
 
 ## Plugin Ecosystem & Development

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -420,6 +420,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - 鲸鱼娘思考状态自定义标签（cordis）
 - [dsh-digipet](https://github.com/swaylq/dsh-digipet) - 数码宝贝式养成宠物：孵蛋、吃真实工作长大（回合、工具、报错都算营养），按工作方式走四条进化路线；零 token、纯命令交互。
 - [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - 宝可梦式捕捉收集：回合、工具、报错刷出野外遭遇，投球捕捉、集 28 格图鉴、组 6 只队伍；零 token、纯命令交互。
+- [dsh-survival](https://github.com/Socialist-Sister/dsh-survival) - Minecraft 生存玩法 Agent 预设：引擎硬结算生命/饥饿/昼夜/怪物，原版配方合成解锁高级工具，铁砧修复，浏览器状态栏；按官方预设插件规范构建。
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
 
 ## Plugin Ecosystem & Development

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,4 +1,4 @@
-<p align="center">
+﻿<p align="center">
 	<a href="README.md">English</a>&nbsp;&nbsp;|&nbsp;&nbsp;
 	<a href="README.zh-CN.md">简体中文</a>
 </p>
@@ -420,7 +420,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [ui-status-label](https://github.com/dsh-external/ui-status-label) - 鲸鱼娘思考状态自定义标签（cordis）
 - [dsh-digipet](https://github.com/swaylq/dsh-digipet) - 数码宝贝式养成宠物：孵蛋、吃真实工作长大（回合、工具、报错都算营养），按工作方式走四条进化路线；零 token、纯命令交互。
 - [dsh-wildmon](https://github.com/swaylq/dsh-wildmon) - 宝可梦式捕捉收集：回合、工具、报错刷出野外遭遇，投球捕捉、集 28 格图鉴、组 6 只队伍；零 token、纯命令交互。
-- [dsh-survival](https://github.com/Socialist-Sister/dsh-survival) - Minecraft 生存玩法 Agent 预设：引擎硬结算生命/饥饿/昼夜/怪物，原版配方合成解锁高级工具，铁砧修复，浏览器状态栏；按官方预设插件规范构建。
+- [dsh-survival](https://github.com/Socialist-Sister/dsh-survival-mode) - Minecraft 生存玩法 Agent 预设：引擎硬结算生命/饥饿/昼夜/怪物，原版配方合成解锁高级工具，铁砧修复，浏览器状态栏；按官方预设插件规范构建。
 - [xiekai886/dsh-MusicPlayer](https://github.com/xiekai886/dsh-MusicPlayer) - 可折叠/展开、自由拖动的悬浮音乐播放器，接入网易云音乐，支持歌单导入和按歌名或歌手搜索单曲导入，边对话边听歌。
 
 ## Plugin Ecosystem & Development


### PR DESCRIPTION
Add **dsh-survival** — a Minecraft-survival game mode for DeepSeek Harness: a game-mode agent preset with hard-settled HP/hunger/day-night/mobs, vanilla crafting gates, anvil repair, a browser status bar, and persistent world saves. Built on the official preset plugin spec (isolate-realm engine + host bridge), v0.1.0.

- README.md (English) and README.zh-CN.md (Chinese) updated in the same PR per contributing.md.
- Category: Fun & Lifestyle (games).