### PR TITLE
Add gewu-tools: model-agnostic visual-inspection pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Management panel: Settings → Plugins.
 
 ## Agents & Orchestration
 
+- [gewu-tools](https://github.com/nyantused-cpun/gewu-tools) - Model-agnostic visual-inspection pipeline for text-only agents: page-by-page HTML screenshots plus a ready-made vision-subagent briefing contract (gewu_prep), then source-code truth verification of every finding (gewu_locate); validated on mimo-v2.5 & qwen3.7-plus.
 - [dsh-collaboration](https://github.com/Socialist-Sister/dsh-collaboration) - Multi-agent collaboration suite: user-configured specialist roster, persistent on-demand dispatch (team_call/team_message/team_status/team_close), clone instances, star-topology relay, model comparison and a multimodal vision bridge.
 
 ## Context & Search

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -288,6 +288,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-plugin-scheduled-tasks](https://github.com/Ceelog/dsh-plugins/tree/main/src/plugins/dsh-plugin-scheduled-tasks) - 按项目调度提示词，在全新的无头 Agent 会话中执行，支持单次、固定间隔和 cron 计划，并持久化运行历史。
 
 ## Output & Deliverables
+- [nyantused-cpun/folio](https://github.com/nyantused-cpun/folio) - Folio（兰亭）：咨询/汇报材料生成引擎（接入材料 → 建立记忆 → 应用方法论 → 生成产出 → 守住质量）——DSH 原生插件栈：15 个工具、会话协议事件、L0 守卫、agent preset；方法论包可换，DSH 下零 key 起步。
 
 - [dsh-report-studio](https://github.com/ciceroyang/dsh-report-studio) - 把 DeepSeek Harness 会话一键变成工作日报/周报/交接文档/公众号文章，附可验证凭据（报告与产物哈希）。
 


### PR DESCRIPTION
Adds [gewu-tools](https://github.com/nyantused-cpun/gewu-tools) to Agents & Orchestration.

**gewu-tools（格物）** — Model-agnostic visual-inspection pipeline for text-only DSH agents: \gewu_prep\ renders an HTML proposal page-by-page and generates a ready-made vision-subagent briefing contract; dispatch any vision subagent; \gewu_locate\ verifies every finding against the HTML source (page id + line number, count=0 means OCR misread). Validated on mimo-v2.5 & qwen3.7-plus: model tier does not determine trustworthiness — context and source verification do. Install: \gewu/scripts/install-gewu-plugins.ps1\. MIT.