### PR TITLE
docs: add desktop-cc-gui

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ Management panel: Settings → Plugins.
 - [dsh-desktop](https://github.com/xiaoyanzi191/dsh-desktop) - Electron desktop wrapper for DeepSeek Harness: double-click to start, automatically manages the dsh Web service lifecycle.
 - [dsh-chat-tools](https://github.com/yj060464-commits/dsh-chat-tools) - Headless terminal companion toolkit: chat.sh continuous-conversation REPL (rolling context, decision-point voting, live workflow streaming, effort switching) + automatic LLM session-log summarization. Zero-dependency bash + Python.
 
+- [ccgui / desktop-cc-gui](https://github.com/zhukunpenglinyutong/desktop-cc-gui) - Multi-engine AI coding desktop client (Tauri): Claude Code, Codex, Gemini, OpenCode, DeepSeek Harness and more in one GUI — not a DSH Web UI shell or `dsh-plugin`.
+
 ## Browser & Remote
 
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - Headed browser embedded in the WebUI, model-driven (Codex-style, zero vision deps).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -272,6 +272,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-chat-tools](https://github.com/yj060464-commits/dsh-chat-tools) - headless 终端伴侣工具链：chat.sh 连续对话 REPL（滚动上下文/决策点拍板/工作流实时透传/思考档位切换）+ 会话日志 LLM 自动总结，零依赖纯 bash+Python
 - [dsh-desktop](https://github.com/xiaoyanzi191/dsh-desktop) - DeepSeek Harness 的 Electron 桌面封装：双击即启动，自动管理 dsh Web 服务生命周期。
 
+- [ccgui / desktop-cc-gui](https://github.com/zhukunpenglinyutong/desktop-cc-gui) - multi-engine AI 编程桌面客户端（Tauri）：统一接入 Claude Code、Codex、Gemini、OpenCode、DeepSeek Harness 等 CLI runtime，不是 DSH Web UI 外壳，也不是 `dsh-plugin`。
+
 ## Browser & Remote
 
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - WebUI 内嵌有头浏览器，模型实时操控（Codex 式，0 视觉依赖）


### PR DESCRIPTION
## Summary
- Add [ccgui / desktop-cc-gui](https://github.com/zhukunpenglinyutong/desktop-cc-gui) under **IDE & Clients** in both `README.md` and `README.zh-CN.md`.
- Positioning: multi-engine AI coding desktop client (Tauri) that includes DeepSeek Harness as a native engine, alongside Claude Code / Codex / Gemini / OpenCode.
- Explicitly **not** a `dsh-plugin` and **not** a re-skinned DSH Web UI shell.

## Notes for reviewers
- Category matches contributing guide: IDE & Clients (desktop / terminal / IDE clients).
- Repo topics use `deepseek-harness` / `dsh` / `desktop-app` (no `dsh-plugin`).
- One-line factual descriptions only.

## Test plan
- [ ] Entry appears under IDE & Clients in both language files
- [ ] Link resolves to https://github.com/zhukunpenglinyutong/desktop-cc-gui
- [ ] Description does not claim plugin installability