### PR TITLE
docs: add dsh-session-pin

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Management panel: Settings → Plugins.
 
 ## Dashboards & Session UX
 
+- [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) - Pin sessions and workspaces to the top of the sidebar with per-pin colors, plus a navigation organizer: boards, tags and saved views, health summaries, and /goto.
 - [dsh-session-cluster](https://github.com/dsh-external/dsh-session-cluster) - Session clustering.
 - [session-chatlog](https://github.com/dsh-external/session-chatlog) - Session chat logs.
 - [dsh-session-archive](https://github.com/lbh1nb/dsh-plugins/tree/main/packages/dsh-session-archive) - Settings section to view archived sessions and permanently delete dead conversations (two-step confirm, running sessions locked).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -204,6 +204,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-premium-themes](https://github.com/xiaoyanzi191/dsh-premium-themes) - 8 套精选配色方案与自定义调色板导入（名称+方案+种子色推导完整 token 映射），设置页「调色板」行，热插拔安装。
 
 ## Dashboards & Session UX
+- [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) - 把会话与工作区置顶到侧边栏顶部（每 pin 换色），另加导航组织器：boards、标签与保存视图、健康摘要与 /goto。
 
 - [dsh-session-cluster](https://github.com/dsh-external/dsh-session-cluster) - 会话聚类
 - [session-chatlog](https://github.com/dsh-external/session-chatlog) - 会话聊天记录


### PR DESCRIPTION
﻿One-line intro: dsh-session-pin pins sessions/workspaces to the sidebar top and 0.4.0 adds the session navigation organizer (boards, tags + saved views, health summaries, /goto).\n\nRepo: https://github.com/PerryLink/dsh-session-pin\n\nBoth language versions updated in the same PR, per contributing.md.\n
