### PR TITLE
docs: add dsh-observe

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Management panel: Settings → Plugins.
 - [dsh-tray](https://github.com/KAIbsb/dsh-tray) - Windows tray manager for DSH Web: start/restart/stop, crash auto-restart, status icon, and autostart.
 - [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - Swaps the filesystem and bash providers for a mirage virtual workspace: file tools and shell commands run over mounted resources (RAM, S3, Redis, Slack, Gmail, Notion, Postgres) instead of the host disk, with per-mount read/write/exec modes, per-command sandbox routing (monty, pyodide, quickjs in process; docker, e2b, daytona remote), and installed CLIs (git, gh, slack, linear, ntn, gws, or one you register) as head words in the virtual terminal.
 - [loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) - OpenTelemetry GenAI tracing for DSH: one span tree per turn (steps, LLM calls with TTFT, tool executions, token usage), exported over standard OTLP to any compatible backend, content capture off by default.
+- [dsh-observe](https://github.com/PerryLink/dsh-observe) - Observability exporter for DSH: turn/step/tool/LLM spans and token/cost metrics from the session/event stream to OTLP and Langfuse, with sanitized prompt/completion capture, async batching, a bounded durable offline buffer, and retry with backoff — off by default.
 
 ## Domain & Specialist Skills
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -474,6 +474,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-tray](https://github.com/KAIbsb/dsh-tray) - Windows 托盘管理器:启动/重启/停止 DSH Web、崩溃自动拉起、状态图标与开机自启。
 - [mirage-dsh](https://github.com/strukto-ai/mirage/tree/main/typescript/packages/dsh) - 把文件系统与 bash 提供者换成 mirage 虚拟工作区：文件工具与 shell 命令作用于挂载的资源（RAM、S3、Redis、Slack、Gmail、Notion、Postgres）而非宿主磁盘，支持按挂载点设置读/写/执行模式、按命令选择沙箱（进程内 monty、pyodide、quickjs；远程 docker、e2b、daytona），并可在虚拟终端中安装 CLI（git、gh、slack、linear、ntn、gws，或自行注册的程序树）作为命令头词。
 - [loongsuite/dsh-plugin](https://github.com/loongsuite/dsh-plugin) - DSH 的 OpenTelemetry GenAI 调用链插件：每轮生成一棵 span 树（步骤、带 TTFT 的 LLM 调用、工具执行、token 用量），通过标准 OTLP 上报到任意兼容后端，正文采集默认关闭。
+- [dsh-observe](https://github.com/PerryLink/dsh-observe) - DSH 的可观测性导出器：session/event 流转为 OTLP 与 Langfuse 的 turn/step/tool/LLM span 与 token/成本指标，带脱敏 prompt/completion 采集、异步批量、有界持久离线缓冲与退避重试——默认关闭。
 
 ## Domain & Specialist Skills
 


### PR DESCRIPTION
Adds dsh-observe to the "Runtime & Operations" category in both READMEs - the contributing.md category table lists observability there.

- Repo: https://github.com/PerryLink/dsh-observe
- Topic: `dsh-plugin` set; `dsh.bundle.patch` manifest declared.
- Entry follows the contributing.md standard: real repo, one-line factual description, no badges or marketing.