### PR TITLE
docs: add dsh-feishu (Notifications & Channels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,7 @@ Management panel: Settings → Plugins.
 
 ## Notifications & Channels
 
+- [dsh-feishu](https://github.com/PGZXB/dsh-feishu) - Feishu (Lark) UI for DeepSeek Harness: panel-driven control console, in-card approvals and questions, live streaming cards, one-QR setup.
 - [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) - Feishu bot.
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - Feishu notifications (session end / input needed).
 - [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) - Feishu meeting reminder: a right-side floating panel listing today's/tomorrow's Feishu meetings with multi-alarm flashing reminders.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -415,6 +415,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Notifications & Channels
 
+- [dsh-feishu](https://github.com/PGZXB/dsh-feishu) - DeepSeek Harness 的飞书 UI：面板驱动控制台，卡内审批与提问，流式卡片，扫码一键配置。
 - [dsh-feishu-bot](https://github.com/dsh-external/dsh-feishu-bot) - 飞书机器人
 - [dsh-feishu-notify](https://github.com/dsh-external/dsh-feishu-notify) - 飞书通知（会话结束/等待输入）
 - [dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier) - 飞书会议提醒：右侧悬浮框显示今日/明日飞书会议，多闹钟闪烁提醒。


### PR DESCRIPTION
Adds dsh-feishu to **Notifications & Channels** (README.md + README.zh-CN.md):

> Feishu (Lark) UI for DeepSeek Harness — panel-driven control console, in-card approvals and questions, live streaming cards, one-QR setup.

Per contributing.md: real repository, one-line factual description, no fluff.