### PR TITLE
Add dsh-whale-meter to Dashboards & Session UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ Management panel: Settings → Plugins.
 - [dsh-session-repair-ui](https://github.com/Semidia/dsh-session-repair-ui) - Session repair button in the conversation header: detects & fixes session-log corruption — tool-call id swaps, empty call ids (`message must have tool source`), unknown event types from disabled plugins (marks `ignorable`), torn zstd tails, missing final-frame newlines; ghost-style UI, auto-backup before writes.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) - Shared multi-agent task board (create / claim / transition / query) over a Cordis service key.
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) - Event-flow audit panel: event types, distribution, counts, and recent events for plugin authors.
+- [dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) - Usage tiers (🐟→🐳) with a locally-estimated percentile and shareable stats card; 46 models across 6 vendors including size-tiered Chinese pricing; backfills pre-install sessions; old-vs-new rates across the 2026-08-17 change.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -270,6 +270,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-session-repair-ui](https://github.com/Semidia/dsh-session-repair-ui) - 会话头部的修复按钮：检测并修复工具调用 ID 对不上、空 call ID、禁用插件产生的未知事件、损坏的 zstd 尾部和缺失的末帧换行，写入前自动备份。
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) - 多 agent 共享任务板（创建/认领/流转/查询），状态物化为 Cordis 协作用键。
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) - 事件流审计面板：观察事件类型/分发模式/计数/最近事件，帮助插件作者理解 harness 内部
+- [dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) - 用量段位（🐟→🐳）与可分享战绩卡，分位本地估算；6 家厂商 46 个模型精准计价，含国内按输入长度分档；回填安装前的会话；8·17 调价前后新旧价对比。
 
 ## IDE & Clients
 


### PR DESCRIPTION
One line in both READMEs, under **Dashboards & Session UX**.

[dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) — a usage ledger for DSH. Keeping the entry factual, here's what it actually does that the neighbouring usage plugins don't:

- **Usage tiers** (🐟→🐳) by monthly token burn, with a shareable stats card. The percentile is computed locally from a distribution curve committed in the repo; the UI labels it an estimate — the plugin uploads nothing, so a real global ranking isn't something I can honestly claim.
- **46 models across 6 vendors**, each checked against the vendor's official pricing page, including **size-tiered Chinese pricing** (GLM-5.1 is ¥6/M under 32K input, ¥8/M above; GLM-4.7 splits three ways by output length).
- **Backfills sessions from before install** — read-only pass over dsh session logs, never writes back.
- **Rate-change aware**: prices are organised by effective period, so 08-16 usage bills at the old rates and 08-17 at the new ones rather than retroactively rewriting history.

Local-only (`~/.dsh/whale-meter/*.jsonl`), no telemetry, MIT. Happy to reword or move it if another category fits better.