### PR TITLE
docs: add dsh-desktop-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,7 @@ Management panel: Settings → Plugins.
 - [dsh-companion](https://github.com/qing3a/dsh-companion) - Desktop shell for DeepSeek Harness (Rust single exe): self-bootstrapping Node, tray, autostart, plugin store.
 
 - [ccgui / desktop-cc-gui](https://github.com/zhukunpenglinyutong/desktop-cc-gui) - Multi-engine AI coding desktop client (Tauri): Claude Code, Codex, Gemini, OpenCode, DeepSeek Harness and more in one GUI — not a DSH Web UI shell or `dsh-plugin`.
+- [dsh-desktop-hub](https://github.com/FlashingChen/dsh-desktop-hub) - Electron desktop hub for the official DSH Web UI with a built-in MCP config converter (Claude Code / Cursor JSON → DSH YAML), Skills / Plugin management consoles, and a bundled Node.js + DSH runtime — no install, no terminal.
 
 ## Browser & Remote
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -297,6 +297,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-companion](https://github.com/qing3a/dsh-companion) - 桌面壳（Rust 单 exe）：双击即用 DSH，自动装 Node、托盘、开机自启、插件市场
 
 - [ccgui / desktop-cc-gui](https://github.com/zhukunpenglinyutong/desktop-cc-gui) - multi-engine AI 编程桌面客户端（Tauri）：统一接入 Claude Code、Codex、Gemini、OpenCode、DeepSeek Harness 等 CLI runtime，不是 DSH Web UI 外壳，也不是 `dsh-plugin`。
+- [dsh-desktop-hub](https://github.com/FlashingChen/dsh-desktop-hub) - 官方 DSH Web UI 的 Electron 桌面中枢：内置 MCP 配置转换器（Claude Code / Cursor JSON 一键转 DSH YAML）与 Skills / Plugin 管理台，捆绑 Node.js + DSH 运行时，免安装、免终端。
 
 ## Browser & Remote
 


### PR DESCRIPTION
Adds [DSH Desktop Hub](https://github.com/FlashingChen/dsh-desktop-hub) to the IDE & Clients section.

Not a plain web-UI wrapper: it ships three built-in management consoles — **MCP config conversion** (Claude Code / Cursor JSON → DSH YAML, paste-and-go), Skills management (import / toggle / visibility), and Plugin management (install / remove / update) — plus a bundled Node.js + `@deepseek-ai/dsh` runtime for download-and-run with no terminal.

README.md and README.zh-CN.md updated.