### PR TITLE
docs: add dsh-score

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,6 +503,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - Plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and community pitfalls.
 - [dsh-popper](https://github.com/1473382/dsh-popper) - Falsification-driven correction loop for agent sessions: risky work commits an evidence-checkable claim first, deterministic gates verify it, falsified claims force mutually exclusive replacement hypotheses with discriminating experiments, and every event lands in an append-only evidence ledger.
 - [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - Auto-updating catalog of the whole `dsh-plugin` topic (2600+ repos): a Cloudflare Worker recrawls every 6 hours, translates English descriptions to Chinese with Workers AI, and serves a ranked search API plus an agent skill that finds and installs plugins on demand.
+- [dsh-score](https://github.com/PerryLink/dsh-score) - Multi-dimensional quality scoring for DSH plugins: a five-dimension score card (install success, maintenance activity, docs completeness, security scan, protocol compliance) with /score command and leaderboard reports; install evidence reserves consumption of dsh-test-drive structured results.
 
 ## Runtime & Operations
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -502,6 +502,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide) - 插件开发知识库，作为按需加载的智能体技能：官方约束、任务工作流、API 参考与社区踩坑。
 - [dsh-popper](https://github.com/1473382/dsh-popper) - 证伪驱动的智能体会话修正循环：高风险操作前先提交可检验主张，确定性 gate 验证结果；主张被证伪后强制给出互斥替代假设并各配判别性实验，全部事件进入只追加的证据账本。
 - [awesome-dsh](https://github.com/stakeswky/awesome-dsh) - `dsh-plugin` topic 全量目录，自动更新（2600+ 仓库）：Cloudflare Worker 每 6 小时重新抓取，用 Workers AI 把英文简介译成中文，并提供相关度检索 API 与按需查找、安装插件的智能体技能。
+- [dsh-score](https://github.com/PerryLink/dsh-score) - DSH 插件多维质量评分：五维（安装成功率/维护活跃度/文档完整性/安全扫描/协议合规）评分卡与总分，/score 命令与排行榜报告；安装证据预留消费 dsh-test-drive 的结构化实测结果。
 
 ## Runtime & Operations
 


### PR DESCRIPTION
分类：Plugin Ecosystem & Development

理由：dsh-score 是对 DSH 插件做多维质量评分与排行榜（五维评分卡、/score 命令、排行榜报告），服务于插件生态本身的评估与发现，与同分类下的 dsh-eval（评测平台）同属生态开发工具，故归入 Plugin Ecosystem & Development。

- 英文：Multi-dimensional quality scoring for DSH plugins: a five-dimension score card (install success, maintenance activity, docs completeness, security scan, protocol compliance) with /score command and leaderboard reports; install evidence reserves consumption of dsh-test-drive structured results.
- 中文：DSH 插件多维质量评分：五维（安装成功率/维护活跃度/文档完整性/安全扫描/协议合规）评分卡与总分，/score 命令与排行榜报告；安装证据预留消费 dsh-test-drive 的结构化实测结果。

中英两个 README 已同一 PR 同步更新。仓库：https://github.com/PerryLink/dsh-score（公开、dsh-plugin topic、Apache-2.0、五语 README、v0.1.0 Release）。