### PR TITLE
docs: add Jannchie/dsh-bill

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ Management panel: Settings → Plugins.
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) - Shared multi-agent task board (create / claim / transition / query) over a Cordis service key.
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) - Event-flow audit panel: event types, distribution, counts, and recent events for plugin authors.
 - [dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) - Usage tiers (🐟→🐳) with a locally-estimated percentile and shareable stats card; 46 models across 6 vendors including size-tiered Chinese pricing; backfills pre-install sessions; old-vs-new rates across the 2026-08-17 change.
+- [dsh-bill](https://github.com/Jannchie/dsh-bill) - Cost tracking: per-turn cost line, spend attributed to tool output / model output / system prompt / commands, budget, forecast; priced per call from models.dev + OpenRouter (8000+ models) and never recomputed.
 
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -278,6 +278,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [plugin-team-board](https://github.com/whyihaveyou/dsh-suite/tree/main/packages/plugins/plugin-team-board) - 多 agent 共享任务板（创建/认领/流转/查询），状态物化为 Cordis 协作用键。
 - [dsh-event-auditor](https://github.com/qing3a/dsh-event-auditor) - 事件流审计面板：观察事件类型/分发模式/计数/最近事件，帮助插件作者理解 harness 内部
 - [dsh-whale-meter](https://github.com/Shiye-10Pages/dsh-whale-meter) - 用量段位（🐟→🐳）与可分享战绩卡，分位本地估算；6 家厂商 46 个模型精准计价，含国内按输入长度分档；回填安装前的会话；8·17 调价前后新旧价对比。
+- [dsh-bill](https://github.com/Jannchie/dsh-bill) - 费用统计：每轮成本行，把花费归因到工具输出 / 模型输出 / 系统提示词 / 终端命令，预算与月度预测；按 models.dev + OpenRouter（8000+ 模型）逐次调用定价，历史不重算。
 
 ## IDE & Clients
 


### PR DESCRIPTION
Adds `dsh-bill` under **Dashboards & Session UX**, in both `README.md` and `README.zh-CN.md`.

https://github.com/Jannchie/dsh-bill — MIT, published on npm as [`dsh-bill`](https://www.npmjs.com/package/dsh-bill), installable with `dsh plugin --profile web add dsh-bill`.

A cost plugin. Two things set it apart from the others already listed:

- **Prices come from an online catalogue** (models.dev + OpenRouter via [`llm-pricing`](https://github.com/Jannchie/llm-pricing), 8000+ entries), so there is no hand-maintained price table to go stale when you switch provider. Each call is priced at its own instant — including the peak / off-peak boundary — and history is never recomputed.
- **It answers "on what", not just "how much"**: the request is split into classified segments at capture time and cost is apportioned by position in the cache prefix, so tool output, model output, system prompt and terminal commands are billed separately. Only the per-category amounts are stored; no prompt text is written to disk.

Also: per-turn cost line, budget, monthly forecast, ~166 live-rate currencies, a `bill_stats` agent tool, and backfill of pre-install history from the session log. English and Chinese follow the DSH language setting.