### PR TITLE
docs: add dsh-change-budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Management panel: Settings → Plugins.
 - [dsh-safeguard](https://github.com/ZhijiangTang/dsh-safeguard) - Pre-execution guardrail: vetoes dangerous shell commands and blocks secret/credential leaks before they run.
 - [dsh-mask](https://github.com/PerryLink/dsh-mask) - PII masking middleware: anonymizes names, phones, emails, ID cards, bank cards, keys, and addresses before the model boundary and restores placeholders at display; plaintext never enters the session log; /mask command plus mask_test tool.
 - [dsh-defend](https://github.com/PerryLink/dsh-defend) - Prompt-injection, jailbreak, and secret-leak detection on the official seams: an Aho-Corasick engine over rules ported from Prompt-Injection-Payloads, Jailbreak-Detector, and Secret-Key-Leaker-Detect gates user messages, tool arguments, and tool results with allow/ask/block tiers, sanitized defend/detection audit events, a defend_report tool, and a destructive-delete command guard.
+- [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - Configurable per-turn budgets that limit distinct files, mutation calls, and UTF-8 payload bytes before supported file-mutation tools run.
 
 ## Output & Deliverables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -416,6 +416,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-safeguard](https://github.com/ZhijiangTang/dsh-safeguard) - 执行前护栏：拦截危险 shell 命令与密钥泄漏，阻止其运行。
 - [dsh-mask](https://github.com/PerryLink/dsh-mask) - PII 脱敏中间件：在模型边界前把姓名/电话/邮箱/身份证/银行卡/密钥/地址替换为占位符，展示层还原；明文绝不入会话日志；/mask 命令 + mask_test 工具。
 - [dsh-defend](https://github.com/PerryLink/dsh-defend) - 官方接缝上的提示注入 / 越狱 / 密钥泄露检测：移植自 Prompt-Injection-Payloads、Jailbreak-Detector 与 Secret-Key-Leaker-Detect 的规则 + Aho-Corasick 引擎，在用户消息、工具参数、工具结果三处按 allow/ask/block 分层拦截，附脱敏 defend/detection 审计事件、defend_report 工具与危险递归删除命令门禁。
+- [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - 可配置的逐回合修改额度，在受支持的文件修改工具执行前限制不同文件数、修改调用数与 UTF-8 载荷字节数。
 
 ## Output & Deliverables
 


### PR DESCRIPTION
## Summary

Adds [`dsh-change-budget`](https://github.com/Raphaelutumn/dsh-change-budget) to the English and Chinese **Security & Governance** sections.

The plugin applies configurable per-turn budgets before supported file-mutation tool bodies run, independently limiting distinct files, mutation calls, and UTF-8 payload bytes.

## Verification

- Both language versions contain the same entry
- `git diff --check` passes
- Plugin verification: 5 test files, 20 tests passed; typecheck and build passed
- Repository declares `dsh.bundle` and includes the `dsh-plugin` topic
