### PR TITLE
docs: add dsh-trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,7 @@ Management panel: Settings → Plugins.
 ## Domain & Specialist Skills
 
 - [pengpengyi92/dsh-quant](https://github.com/pengpengyi92/dsh-quant) - Agent-native quantitative R&D toolkit for DSH: 46 tools across 6 domains (data, alpha, ML, risk, execution, ecosystem) with an end-to-end PDAT→PET research pipeline.
+- [maddogfinance/dsh-trading](https://github.com/maddogfinance/dsh-trading) - Research-only trading workbench plugins: typed market-data seam (bring your own provider), multi-timeframe indicator regime snapshot, interactive chart cards in dsh web with provenance-gated model annotations, and a risk-guard that blocks execution-shaped tool calls at the pre-execute gate.
 
 - [gongyijie85/mattpocock-skills-dsh](https://github.com/gongyijie85/mattpocock-skills-dsh) - Matt Pocock's full promoted skill set (25 SKILL.md: grilling, writing-for-agents, wait-what, TDD, code review, wayfinder, ask-matt router) ported to DSH.
 - [gongyijie85/mattpocock-skills-dsh-zh](https://github.com/gongyijie85/mattpocock-skills-dsh-zh) - Matt Pocock's 25 skills fully translated to Chinese (technical terms kept in English with glosses).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -572,6 +572,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Domain & Specialist Skills
 
 - [pengpengyi92/dsh-quant](https://github.com/pengpengyi92/dsh-quant) - Agent-native 量化研究工具箱：46 工具 · 6 域（数据/因子/ML/风控/执行/生态），一条管线跑通 PDAT→PET。
+- [maddogfinance/dsh-trading](https://github.com/maddogfinance/dsh-trading) - 只读交易研究工作台插件：带类型的行情数据接缝（可自带数据源）、多周期指标 regime 快照、dsh web 交互式 K 线卡（模型标注需溯源且经价格区间校验）、以及在 pre-execute 门拦截下单形工具调用的 risk-guard。
 
 - [gongyijie85/mattpocock-skills-dsh](https://github.com/gongyijie85/mattpocock-skills-dsh) - Matt Pocock 完整发布技能集（25 个 SKILL.md：grilling、writing-for-agents、wait-what、TDD、code-review、wayfinder、ask-matt 路由）的 DSH 移植。
 - [gongyijie85/mattpocock-skills-dsh-zh](https://github.com/gongyijie85/mattpocock-skills-dsh-zh) - Matt Pocock 25 个技能正文全译中文（技术术语保留英文并附注释）。


### PR DESCRIPTION
Adds **dsh-trading** to Domain & Specialist Skills (both README.md and README.zh-CN.md).

- Repo: https://github.com/maddogfinance/dsh-trading (MIT, `dsh-plugin` topic)
- npm: all packages published under `@dsh-trading/*`; one-command install: `dsh plugin --profile trading add @dsh-trading/bundle`
- What it is: research-only trading workbench plugins — typed `ctx.marketData` provider seam (bring your own data), deterministic multi-timeframe indicator regime snapshot, interactive chart cards in dsh web (chip-toggled indicator panes drawn from the model's own per-bar series), model-authored chart annotations behind a provenance + price-range validation gate, and a risk-guard that refuses execution-shaped tool calls at `tools/pre-execute`.
- Demo: https://www.youtube.com/watch?v=9KLpy-jPtKY