### PR TITLE
Add dsh-memory-porter (Memory & Knowledge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Management panel: Settings → Plugins.
 - [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW: memory + knowledge base + document search for DSH, reachable from ANY device on your LAN — built on a production-grade AI platform (team-ready, up to ~20 people).
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - Mnemonic layer.
 - [memory-mcp-server](https://github.com/BingoAgentTouch/Personal_MCP) - Layered long-term memory MCP server: raw turns → task fragments → daily summaries → topic indexes, local MiniLM 384-dim embeddings or OpenAI-compatible API backend, semantic + Jaccard-fallback search, one-command DSH plugin install.
+- [dsh-memory-porter](https://github.com/Shiye-10Pages/dsh-memory-porter) - Cross-vendor memory migration: zero-token import of the `memories.json` in a Claude export, local Claude Code transcripts without an export, and conversations distilled through the host's own model; every memory carries verbatim evidence checked against the source by code.
 ## Input & Editing
 
 - [Zhangbo-cn/dsh-voice-input-plugin](https://github.com/Zhangbo-cn/dsh-voice-input-plugin) - Composer mic for the Web UI: tap-to-monitor live transcription and hold-to-talk, with host Edge TTS reply reading that streams while the model generates, echo-pause during reading, and tap-to-stop.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -146,6 +146,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [ccch713/deepddw](https://github.com/ccch713/deepddw) - deepDDW：为 DSH 补齐记忆 + 知识库 + 文档检索，局域网内任意设备（电脑/手机/平板）可访问——封装自企业级 AI 底座平台（团队就绪，支持 20 人以下小团队）。
 - [dsh-mnemon](https://github.com/dsh-external/dsh-mnemon) - 助记层
 - [memory-mcp-server](https://github.com/BingoAgentTouch/Personal_MCP) - 分层长期记忆 MCP 服务器：原始轮次 → 任务片段 → 每日总结 → 主题索引；本地 MiniLM 384 维嵌入或 OpenAI 兼容 API 后端，语义 + Jaccard 兜底检索，支持 dsh plugin add 一键安装。
+- [dsh-memory-porter](https://github.com/Shiye-10Pages/dsh-memory-porter) - 跨厂商记忆迁移：Claude 导出里的 `memories.json` 零 token 入库、本机 Claude Code 记录免导出直读、历史对话用宿主已配的模型提纯；每条记忆都带由代码回原文核对的逐字证据。
 ## Input & Editing
 
 - [Zhangbo-cn/dsh-voice-input-plugin](https://github.com/Zhangbo-cn/dsh-voice-input-plugin) - 输入框麦克风：点击持续监控、按住对话；浏览器语音识别逐字上屏，回复由 host Edge TTS 边生成边朗读（句子切分），朗读时暂停识别防回声，点击可停止。


### PR DESCRIPTION
One entry under **Memory & Knowledge**, added to both `README.md` and `README.zh-CN.md`.

Cross-vendor memory migration: it reads the `memories.json` inside a Claude account export (already distilled, so zero tokens), local Claude Code transcripts with no export needed, and distills conversations through whichever model the user already configured in DSH — no extra API key.

The distinguishing part is mechanical rather than promotional: evidence for every memory is checked against the source text by code, not accepted on the model's word. In a real run over a 7-conversation export, 6 of 25 candidates were dropped for not matching, and evidence found only in the assistant's turns is routed to review rather than stored.

Note on scope, to save you the check: [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) already in this list also migrates, but it replays sessions as resumable DSH sessions from four local CLIs. This one distills memories and covers the account-level exports it does not touch. They compose rather than compete.

MIT, published on npm as `dsh-memory-porter`, zero runtime dependencies, `dsh-plugin` topic present.