### PR TITLE
docs: add dsh-dream-skin under UI, Themes & Interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-help](https://github.com/Semidia/dsh-plugin-help) - Installed-plugins README summary panel: floating 📖 button, zh-preferring titles, default-all-expanded READMEs, blue circular index badges, per-plugin one-click update (`dsh plugin update`) via a loopback endpoint.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - MCP management console for the official DSH MCP client: server CRUD with approval-gated, backed-up profile writes, a tool trial console through the official tool pipeline, health diagnostics, and connection status.
 - [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) - Pin sessions and workspaces to the top of the sidebar with per-pin colors, plus a navigation organizer: boards, tags and saved views, health summaries, and /goto.
+- [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) - One-command skinning for DSH Web: 8 original themes, wallpaper (opacity/blur/gradient/URL), per-user accent, and shareable theme packs + favorites + surprise-me. Purely native token system.
 
 ## Dashboards & Session UX
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -234,6 +234,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - 官方 MCP 客户端（dsh-mcp-client）的管理控制台：/mcp 命令与设置页 MCP 页签提供服务器增删改（审批门 + 自动备份的 profile 写入）、走官方工具管线的工具试用台、健康诊断与连接状态。
 - [dsh-premium-themes](https://github.com/xiaoyanzi191/dsh-premium-themes) - 8 套精选配色方案与自定义调色板导入（名称+方案+种子色推导完整 token 映射），设置页「调色板」行，热插拔安装。
 - [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) - 把会话与工作区置顶到侧边栏顶部（每 pin 换色），另加导航组织器：boards、标签与保存视图、健康摘要与 /goto。
+- [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) - DSH Web 一键换肤插件：8 套原创主题、背景壁纸（透明度/模糊/渐变/URL）、每用户强调色、主题包导入导出/分享链接、收藏与随机，纯原生 token 系统。
 
 ## Dashboards & Session UX
 


### PR DESCRIPTION
## 变更

在两个 README 的 **UI, Themes & Interaction** 分类下新增 [dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) 条目：

- **README.md**（English）：one-command skinning description
- **README.zh-CN.md**（中文）：一键换肤中文描述

dsh-dream-skin 声明 dsh.bundle，已发布 npm 0.3.0。

## 说明

- 仅 Markdown 改动，按 CONTRIBUTING 无需跑测试
- 已核验 JSON/结构完整、两个语言版本同 PR