### PR TITLE
docs: add dsh-branch-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Management panel: Settings → Plugins.
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - Pin assistant replies from the Web action strip and recall them into the next model turn (`/pin` `/recall`, with optional wake).
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn navigation plugin.
 - [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - Git-style conversation fork graph in the session header: colored lanes and fork curves show which session branched from which, with click-to-jump navigation.
+- [chouyong/dsh-branch-review](https://github.com/chouyong/dsh-branch-review) - Track human decisions for related DSH session branches: keep, discard, or follow up with reasons, labels, and external links.
 - [dsh-fork-diff](https://github.com/chouyong/dsh-fork-diff) - Read-only parent and sibling branch comparison in DSH Web: message and tool diffs, usage and latency summaries, filters, and open-session navigation.
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - Token usage statistics as a Settings page: cumulative KPIs, a six-month activity heatmap, stacked per-model daily bars and a model donut, rescanned read-only from session logs.
 - [dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) - Session-wide file change review in the session header. Lists every file the agent wrote this session with its hunks, counts refused writes separately from changes, and folds from a session projection rather than the on-disk log.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,6 +249,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - 在 Web 助手消息操作条钉住回复，再通过 `/pin` `/recall` 召回进下一轮模型上下文（可一键唤醒）。
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn 导航插件。
 - [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - 会话标题栏内联的 Git 风格 fork 血缘图：用彩色轨道与分叉曲线显示会话从何处分支，并可点击跳转。
+- [chouyong/dsh-branch-review](https://github.com/chouyong/dsh-branch-review) - 为相关 DSH 会话分支记录人工决策：保留、淘汰或待跟进，并保存理由、标签与外部链接。
 - [dsh-fork-diff](https://github.com/chouyong/dsh-fork-diff) - DSH Web 的只读父分支与兄弟分支比较：展示消息与工具差异、用量与耗时摘要，支持筛选和打开对应会话。
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - 设置页 Token 用量统计：累计 KPI、半年活跃热力图、按模型堆叠的每日柱状图与模型环形图，只读重算会话日志。
 - [dsh-what-changed](https://github.com/sjh9714/dsh-what-changed) - 会话顶栏的整会话改动审阅。列出本次会话 Agent 写过的每个文件与逐处改动，被权限拒绝的写入单独计数不算改动，数据来自 session projection 而非磁盘日志。


### PR DESCRIPTION
## Summary

Adds [`chouyong/dsh-branch-review`](https://github.com/chouyong/dsh-branch-review) to the English and Chinese `Dashboards & Session UX` lists. The plugin records explicit human decisions for related DSH session branches — keep, discard, or follow up — with reasons, labels, and external links.

Both language entries are concise, factual, and contain no screenshots or marketing claims.

## Verification

- Product repository is public, created `2026-08-16T11:35:26Z`, exceeds the 10-commit requirement, and carries the `dsh-plugin` topic
- Real DSH `0.1.0-rc.5` Web flow: one completed parent plus two completed sibling forks
- Plugin client asset: HTTP 200; console errors, page errors, and failed requests: 0
- Focused diff contains only `README.md` and `README.zh-CN.md`
- `git diff --check upstream/main...HEAD`: passed
- Full-repo `awesome-lint README.md` reaches the existing upstream `vision_analyze` casing error at line 345; the new entry itself is at lines 251/252 and introduces no lint finding