### PR TITLE
docs: add opencues/opencues

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Management panel: Settings → Plugins.
 - [dsh-prompt-optimize](https://github.com/peterliucius/dsh-prompt-optimize) - Rewrite the current composer draft through an auxiliary LLM call without sending a message.
 - [Boliban/dsh-enter-customizer](https://github.com/Boliban/dsh-enter-customizer) - Take over the system input shortcuts for the chat input box and configure behavior independently for each shortcut.
 - [PerryLink/dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) - Terminal-style input history for the web composer (edge-first arrows, draft/caret restore, Ctrl+R search, sliding-context awareness) plus a smart input layer: cross-session snippets, prompt templates with variables, reuse insights, and compaction-summary highlighting.
+- [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) - Word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings are flagged as you type. Routes through `ctx.llm`, so it needs no API key of its own.
 
 ## UI, Themes & Interaction
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -184,6 +184,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [Boliban/dsh-enter-customizer](https://github.com/Boliban/dsh-enter-customizer) - 接管聊天输入框的回车等快捷键，每个快捷键的行为都能单独配置。
 - [PerryLink/dsh-composer-history](https://github.com/PerryLink/dsh-composer-history) - 为 Web 作曲器提供终端风格输入历史（边缘优先方向键、草稿/光标还原、Ctrl+R 搜索、滑动上下文感知），另加智能输入层：跨会话片段、带变量的提示模板、复用洞察与压缩摘要高亮。
 - [dsh-file-upload](https://github.com/a903067276-rgb/dsh-file-upload) - 一键上传 + 拖拽文件进对话：保存到项目 uploads/、路径文本进输入框，可配合任意视觉工具。
+- [opencues/opencues](https://github.com/opencues/opencues/tree/master/integrations/dsh) - 输入框内的同义词提示与下划线补全：行尾输入 `_` 即自动填充，拼写错误随打随标。走 `ctx.llm`，无需自备 API key。
 
 ## UI, Themes & Interaction
 


### PR DESCRIPTION
Adds OpenCues under **Input & Editing**, in both `README.md` and `README.zh-CN.md`.

Word alternatives and underscore-gated fill-ins in the composer: end a line with `_` and it is filled, misspellings are flagged as you type. It routes through `ctx.llm`, so it needs no API key of its own — it uses whichever model dsh is already configured with.

Install: `dsh plugin --profile web add @opencues/dsh` (published to npm with the browser bundle prebuilt, so it skips pnpm's `allowBuilds` step).

Per contributing.md: one line, no badges, no screenshots, no marketing language, both language files updated together, and it is a real working project rather than a draft — verified end to end against the published package on a clean machine with no config and no API keys, where `the capital of iceland is _` fills to `Reykjavik` on DeepSeek's own model.