### PR TITLE
docs: add dsh-plugin-pub-review

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Management panel: Settings → Plugins.
 - [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - Routes eligible bash commands through rtk (Rust Token Killer) inside the DSH bash executor to compress tool output and save tokens; safe passthrough when rtk is absent.
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - Structured Git tools (status/diff/log/branch/stage/commit/stash/show) with a destructive-command guard.
 - [dsh-plugin-check](https://github.com/dsh-external/dsh-plugin-check) - Plugin health checks (manifest/patch format/build pitfalls/hub status).
+- [dsh-plugin-pub-review](https://github.com/weopenfire-git/dsh-plugin-pub-review) - Publish-readiness review for DSH plugins: official docs freshness check, 30+ static checks with a Ready/Not-Ready verdict, and publish preflight + command guidance.
 - [dsh-ops-skill](https://github.com/dragon43pp/dsh-ops-skill) - Read-only DSH runtime reliability kit: versioned redacted state contracts, protected snapshots, review-oriented upgrade diffs, and isolated regression checks; no privileged Docker default. *Folder-based Skill; not a DSH profile bundle.*
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) - Writes local JSONL summaries of per-turn tool counts and coarse verification signals without storing prompts, tool arguments, or result text.
 - [dsh-inspect](https://github.com/dsh-external/dsh-inspect) - Adversarial checkup → fix → review loop.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -394,6 +394,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-bash-rtk](https://github.com/DeepTrial/dsh-bash-rtk) - 在 DSH bash 执行器内把符合条件的 bash 命令路由给 rtk（Rust Token Killer）以压缩工具输出、节省 token；rtk 缺失时安全透传。
 - [dsh-tool-git](https://github.com/lxj808624/dsh-tool-git) - 结构化 Git 工具（status/diff/log/branch/stage/commit/stash/show）+ 破坏性命令安全护栏
 - [dsh-plugin-check](https://github.com/dsh-external/dsh-plugin-check) - 插件健康检查（清单/patch 格式/构建陷阱/hub 收录）
+- [dsh-plugin-pub-review](https://github.com/weopenfire-git/dsh-plugin-pub-review) - 给 DSH 插件做发布就绪审查：官方文档新鲜度检查、30+ 项静态检查并给 Ready/Not-Ready 判定、发布预检与命令引导。
 - [dsh-ops-skill](https://github.com/dragon43pp/dsh-ops-skill) - 只读 DSH 运行时可靠性工具包：版本化脱敏状态契约、受保护快照、面向人工审查的升级差异与隔离回归检查；默认不使用特权 Docker。*文件夹式 Skill，不是 DSH profile bundle。*
 - [dsh-verification-receipt](https://github.com/030611/dsh-verification-receipt) - 把每轮工具计数与粗粒度验证信号写入本地 JSONL，不保存提示词、工具参数或结果正文。
 - [dsh-inspect](https://github.com/dsh-external/dsh-inspect) - checkup → fix → review 对抗式闭环


### PR DESCRIPTION
Add \dsh-plugin-pub-review\ (\@yinging/dsh-plugin-pub-review\ on npm) to the **Git & Engineering** category, next to \dsh-plugin-check\.

Publish-readiness review for DSH plugins: official docs freshness check (docs-check, GitHub contents API sha compare + local checkout fallback), 30+ static checks with a Ready/Not-Ready verdict (plugin-review), and publish preflight + command guidance (plugin-publish).

Repo: https://github.com/weopenfire-git/dsh-plugin-pub-review
npm: https://www.npmjs.com/package/@yinging/dsh-plugin-pub-review