### PR TITLE
Add dsh-cn-boot + dsh-llms-forge

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -30,6 +30,8 @@
 | 仓库 | 描述 |
 |---|---|
 | [7d7d](https://github.com/dsh-external/7d7d) | 7k7k 风格小游戏平台：模型生成/上传 HTML5 与 Flash 小游戏，Web UI 内直接游玩（Ruffle 模拟 Flash） |
+| [dsh-cn-boot](https://github.com/zoahdev/dsh-cn-boot) | 国内网络引导：探测 npm/npmmirror/GitHub/HuggingFace/Gitee 与本地代理，推荐镜像/代理并生成 PowerShell + bash 引导脚本（默认只读，apply 显式） |
+| [dsh-llms-forge](https://github.com/zoahdev/dsh-llms-forge) | 为 dsh 插件仓库从 package.json + README 生成 llms.txt（AI 可读发现文件），默认只读 |
 | [DSH-UI4A](https://github.com/dsh-external/DSH-UI4A) | UI4A（UI for Agent）的 DSH 实现（macaron-ui4a-interactive-ai） |
 | [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) | 右侧侧边栏增强：文件预览/终端/Git，可拖拽自定义位置 |
 | [chat-width](https://github.com/dsh-external/chat-width) | 自由调节正文与输入框的展示宽度 |


### PR DESCRIPTION
Add two verified zoahdev plugins to the single-plugin catalog:

- [dsh-cn-boot](https://github.com/zoahdev/dsh-cn-boot) — China-network bootstrap for dsh: probes npm/npmmirror/GitHub/HuggingFace/Gitee and local proxies, mirror/proxy recommendations, generated PowerShell + bash bootstrap. Read-only by default.
- [dsh-llms-forge](https://github.com/zoahdev/dsh-llms-forge) — generates llms.txt for plugin repos from package.json + README (AI-readable discovery).

Both: 10/8 unit tests, CI (doctor preflight + packed-artifact integration + fresh-profile dsh web boot smoke on Windows), published on npm (0.1.0), verified with \dsh plugin add\.