### PR TITLE
Add dsh-timesheet — turn-based time tracking

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -30,6 +30,7 @@
 | 仓库 | 描述 |
 |---|---|
 | [7d7d](https://github.com/dsh-external/7d7d) | 7k7k 风格小游戏平台：模型生成/上传 HTML5 与 Flash 小游戏，Web UI 内直接游玩（Ruffle 模拟 Flash） |
+| [dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) | 从会话日志做基于 turn 的时间跟踪：按天/项目/供应商/来源汇总、工具调用数、失败率、首 token 延迟 |
 | [DSH-UI4A](https://github.com/dsh-external/DSH-UI4A) | UI4A（UI for Agent）的 DSH 实现（macaron-ui4a-interactive-ai） |
 | [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) | 右侧侧边栏增强：文件预览/终端/Git，可拖拽自定义位置 |
 | [chat-width](https://github.com/dsh-external/chat-width) | 自由调节正文与输入框的展示宽度 |


### PR DESCRIPTION
Add [dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) to the single-plugin catalog.

**What it does:** turn-based time tracking from dsh session logs — totals, per-day/project/provider/source rollups, tool-call counts, failure rates, time-to-first-token. CLI + agent-callable \	imesheet\ tool, \dsh-timesheet/v1\ reports, zero runtime dependencies.

**Verification:** 7 unit tests, CI (doctor preflight + packed-artifact integration + fresh-profile dsh web boot smoke on Windows), npm \dsh-timesheet@0.1.0\ published, verified against real session logs (52 turns / 4h56m / 1315 tool calls).