### PR TITLE
Add dsh-discussions-radar — official Discussions radar

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -30,6 +30,7 @@
 | 仓库 | 描述 |
 |---|---|
 | [7d7d](https://github.com/dsh-external/7d7d) | 7k7k 风格小游戏平台：模型生成/上传 HTML5 与 Flash 小游戏，Web UI 内直接游玩（Ruffle 模拟 Flash） |
+| [dsh-discussions-radar](https://github.com/zoahdev/dsh-discussions-radar) | 官方 Discussions 雷达：列出/筛选/搜索官方讨论区（Ideas/Q&A/Show Your Plugins!/General/Announcements） |
 | [DSH-UI4A](https://github.com/dsh-external/DSH-UI4A) | UI4A（UI for Agent）的 DSH 实现（macaron-ui4a-interactive-ai） |
 | [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) | 右侧侧边栏增强：文件预览/终端/Git，可拖拽自定义位置 |
 | [chat-width](https://github.com/dsh-external/chat-width) | 自由调节正文与输入框的展示宽度 |


### PR DESCRIPTION
Add [dsh-discussions-radar](https://github.com/zoahdev/dsh-discussions-radar) to the single-plugin catalog.

**What it does:** lists/filters/searches the official deepseek-ai/deepseek-harness discussion boards (Ideas / Q&A / Show Your Plugins! / General / Announcements / Polls) from inside dsh or the CLI — the community-pulse companion to dsh-github-release-radar. CLI + agent-callable \discussions_radar\, \dsh-discussions-radar/v1\ reports, zero runtime deps, read-only public API.

**Verification:** 11 unit tests, CI (doctor preflight + packed-artifact integration against the live GitHub API + fresh-profile dsh web boot smoke on Windows), npm \dsh-discussions-radar@0.1.0\ published.