### PR TITLE
Add stacktree-dsh to Output & Deliverables

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,6 +480,7 @@ Management panel: Settings → Plugins.
 - [dsh-translate](https://github.com/PerryLink/dsh-translate) - Vendor parameter translation and deterministic JSON repair for DeepSeek Harness: a /translate command maps 13 canonical parameters across 11 vendors, and the post-execute repair layer (plus fix_json) fixes broken JSON tool output without fabricating data.
 - [inspiration-deck-workshop](https://github.com/zjsthmjialin/inspiration-deck-workshop) - Registers the Inspiration Deck Workshop skill: local static HTML presentation decks (6 deck templates, 25+ layouts, themes & motion showroom) with a validate + PNG/PDF export CLI, zero runtime deps.
 - [pdf-background-gray-codex-skill](https://github.com/zjsthmjialin/pdf-background-gray-codex-skill) - Whitens gray/off-white scan backgrounds in image-based PDFs while preserving resolution, page geometry and anti-aliased text edges (lossless Flate write-back) via a single Python script.
+- [stacktree-dsh](https://github.com/stevysmith/stacktree-dsh) - Cordis overlays that connect the Stacktree MCP server (stdio or Streamable HTTP): publish generated HTML to an unguessable private URL a client opens with no account, replace it in place so the link stays valid, and gate it by passcode or email domain.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -479,6 +479,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [inspiration-deck-workshop](https://github.com/zjsthmjialin/inspiration-deck-workshop) - 注册灵感演示工坊技能：本地静态 HTML 演示文稿（6 套 deck 模板、25+ 布局、主题与动效展示馆），带 validate 校验与 PNG/PDF 导出 CLI，零运行时依赖。
 - [pdf-background-gray-codex-skill](https://github.com/zjsthmjialin/pdf-background-gray-codex-skill) - 去除扫描 PDF 的灰色/米白底色，保持分辨率、页面几何与抗锯齿文字边缘（无损 Flate 写回），核心为单文件 Python 脚本。
 - [JohnXu22786/docgen](https://github.com/JohnXu22786/docgen) - 文档工坊技能包：纯提示词（Agent Skills）文档生成——README、PR 描述、changelog 与代码审查；零第三方依赖。
+- [stacktree-dsh](https://github.com/stevysmith/stacktree-dsh) - 连接 Stacktree MCP 服务端的 Cordis 覆盖配置（stdio 或 Streamable HTTP）：把生成的 HTML 发布到不可猜测的私有链接，客户无需账号即可打开；支持原地替换以保持链接长期有效，并可用密码或邮箱域名设置访问门槛。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Adds [stacktree-dsh](https://github.com/stevysmith/stacktree-dsh) under **Output & Deliverables**, in both README.md and README.zh-CN.md.

Two Cordis overlays that connect the Stacktree MCP server to DSH via `@deepseek-ai/dsh-mcp-client` — hosted over Streamable HTTP, or stdio through the `stacktree-mcp` npm package. Tools arrive as `mcp__stacktree__publish_html`, `update_site`, and the rest of the 19-tool surface.

It sits next to the generators in this category rather than duplicating them: those turn a session into an HTML deliverable, this puts one in front of someone who is not at the terminal — an unguessable private URL the recipient opens with no account, replaceable in place so a link already sent stays current, and gateable by passcode or email domain.

Repo carries the `dsh-plugin` topic. No new category needed.