### PR TITLE
Add dsh-readme-forge — README generator for plugin repos

### DIFF
--- a/CATALOG.md
+++ b/CATALOG.md
@@ -30,6 +30,7 @@
 | 仓库 | 描述 |
 |---|---|
 | [7d7d](https://github.com/dsh-external/7d7d) | 7k7k 风格小游戏平台：模型生成/上传 HTML5 与 Flash 小游戏，Web UI 内直接游玩（Ruffle 模拟 Flash） |
+| [dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) | 为 dsh 插件仓库生成 README.md（package.json + cordis.patch.yml + 源码布局，默认只读） |
 | [DSH-UI4A](https://github.com/dsh-external/DSH-UI4A) | UI4A（UI for Agent）的 DSH 实现（macaron-ui4a-interactive-ai） |
 | [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) | 右侧侧边栏增强：文件预览/终端/Git，可拖拽自定义位置 |
 | [chat-width](https://github.com/dsh-external/chat-width) | 自由调节正文与输入框的展示宽度 |


### PR DESCRIPTION
Add [dsh-readme-forge](https://github.com/zoahdev/dsh-readme-forge) to the single-plugin catalog.

**What it does:** generates README.md for dsh plugin repos from package.json + cordis.patch.yml + source layout (install/CLI/tools/dev/license sections). Deterministic, zero runtime deps, read-only by default. CLI + agent-callable \eadme_forge\, \dsh-readme-forge/v1\ results. Companion to dsh-llms-forge (README → llms.txt pipeline).

**Verification:** 10 unit tests, CI (doctor preflight + packed-artifact integration + fresh-profile dsh web boot smoke on Windows), npm \dsh-readme-forge@0.1.0\ published.