### PR TITLE
docs: add dsh-voice-gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,7 @@ Management panel: Settings → Plugins.
 - [zoahdev/dsh-browser-use](https://github.com/zoahdev/dsh-browser-use) - Browser Use cloud bridge: run real web tasks (open pages, click, type, fill forms, extract data) through the Browser Use API.
 - [dsh-antigravity](https://github.com/LiZhenNet/dsh-antigravity) - Google Antigravity / Cloud Code Assist model provider for DSH with native Web OAuth, real-time quota tracking, and dynamic reasoning effort routing.
 - [JohnXu22786/model-catalog](https://github.com/JohnXu22786/model-catalog) - Model catalog auto-discovery: fetch model listings, pricing and capabilities from OpenAI-compatible API hosts, normalized into ready-to-use config.
+- [dsh-voice-gate](https://github.com/yangfei222666-9/dsh-voice-gate) - Voice-first mobile gate into DSH: a zero-dependency Python service (port 3081) with a PWA page that sends voice or text to the current session, token auth, launchd autostart, and a Tailscale HTTPS recipe.
 
 ## Models & Inference
 - [dsh-image-gen](https://github.com/shanliuling/dsh-image-gen) - Native image generation for DeepSeek Harness with Google Gemini, OpenAI Images, OpenAI-compatible APIs, and ByteDance Seedream.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -359,6 +359,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-antigravity](https://github.com/LiZhenNet/dsh-antigravity) - Google Antigravity / Cloud Code Assist 模型提供者插件：支持 Web OAuth 登录、实时额度同步、精选 11 个 Base 模型与动态思考档位路由。
 - [JohnXu22786/browser-automation](https://github.com/JohnXu22786/browser-automation) - Web Bridge：面向 dsh 的浏览器自动化 MCP 服务器——真实浏览器导航、点击、填表、截图、JS 执行，由无障碍树快照驱动。
 - [JohnXu22786/computer-control](https://github.com/JohnXu22786/computer-control) - 面向 dsh 的桌面控制：屏幕捕获、指针/键盘注入、无障碍树语义操作，紧急停止、允许/拒绝规则、确认流程与空闲待机。
+- [dsh-voice-gate](https://github.com/yangfei222666-9/dsh-voice-gate) - 语音优先的手机入口：零依赖 Python 服务（3081 端口）+ PWA 页面，把语音或文字发送到当前 DSH 会话，Token 鉴权、launchd 自启、Tailscale HTTPS 配方。
 
 ## Models & Inference
 - [dsh-image-gen](https://github.com/shanliuling/dsh-image-gen) - 为 DeepSeek Harness 提供原生对话生图能力，支持 Google Gemini、OpenAI Images、OpenAI 兼容 API 和字节 Seedream。


### PR DESCRIPTION
### 项目
[dsh-voice-gate](https://github.com/yangfei222666-9/dsh-voice-gate) —— 给 DeepSeek Harness 装一扇「语音门」:手机网页按住说话 → 自动转文字 → 一键发送到当前 DSH 会话(3081 端口)。

### 为何值得收录
- **MIT、零第三方依赖**:纯 Python 标准库 + 单文件前端,一个 voice_server.py 即可跑起来。
- **语音优先的移动入口**:补齐 DSH 在手机 / 远程场景下的输入短板,支持 PWA 加到主屏像 App 一样用。
- **安全**:自动生成 Token(0600 权限)鉴权,路径穿越防护,文本长度上限。
- **开箱即用的运维配方**:macOS launchd 自启、Tailscale HTTPS 反向代理(出门全球可用 / 不配也能局域网用)。

### 改动
在 Browser & Remote(远程接入)分类末尾,英文 README.md 与中文 README.zh-CN.md 各新增一条,严格按现有 `- [名称](链接) - 一句话描述` 格式,描述与仓库 README/源码逐项对齐。