### PR TITLE
docs: add dsh-desk-pet

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,7 @@ Management panel: Settings → Plugins.
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF toolbox: extract text, metadata, and page ranges via pdfjs-dist (local, no API key).
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - Pixel whale companion (blink/tail/spout/hearts).
 - [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - Desktop whale pet with live session state.
+- [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) - macOS desk pet in a real always-on-top window rather than a page widget: six states from local DSH, native right-click menu, and a bundled skill that turns one photo into a full eighteen-pose skin.
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - Desktop pet, Rust edition.
 - [dsh-stickers](https://github.com/dsh-external/dsh-stickers) - Stickers.
 - [dsh-ads](https://github.com/dsh-external/dsh-ads) - 2005 Chinese-web-style ad layer (joke plugin).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -523,6 +523,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF 工具箱：基于 pdfjs-dist 提取文本、元数据与页码范围（本地解析，无需 API key）。
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - 像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）
 - [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - 桌面小鲸鱼，实时感知会话状态
+- [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) - 用真的置顶窗口而不是页面挂件实现的 macOS 桌宠：六种状态跟着本地 DSH 走，原生右键菜单，自带的 skill 把一张照片变成整套十八个姿势的皮肤。
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - 桌宠 Rust 版
 - [dsh-stickers](https://github.com/dsh-external/dsh-stickers) - 贴纸
 - [dsh-ads](https://github.com/dsh-external/dsh-ads) - 2005 中文站风格广告层（整活）


### PR DESCRIPTION
Adds [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) under **Fun & Lifestyle**, next to the other pets. Both language versions updated in this PR, one line each.

A macOS desk pet for DSH: a real AppKit window on the desktop rather than a widget drawn inside the DSH page, so it stays above whatever you are working in — fullscreen Spaces included — and follows the agent through idle, working, waiting on a confirmation, error, just-finished, and dozing.

The list already carries several pets, so the part that is not already covered: a bundled skill expands **one photo into a whole skin** — the eighteen poses a skin needs, generated by the user's own image tool on their own credentials, with nothing sent anywhere by the plugin. It runs on the system `/usr/bin/python3` through `ctypes`, with no Electron and no dependencies; the frame pipeline is standard library, which is what makes generating a skin locally possible.

macOS only — the renderer is AppKit. Stated in the README rather than left to be discovered.

Installable today: `dsh plugin --profile web add deepseek-desk-pet`. The npm package and the repo are named differently because npm rejected `dsh-desk-pet` as too similar to an unrelated package.
