### PR TITLE
docs: add dsh-session-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Management panel: Settings → Plugins.
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - Pin assistant replies from the Web action strip and recall them into the next model turn (`/pin` `/recall`, with optional wake).
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn navigation plugin.
 - [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - Git-style conversation fork graph in the session header: colored lanes and fork curves show which session branched from which, with click-to-jump navigation.
-- [dsh-session-tree](https://github.com/ZhengQingJing/dsh-session-tree) - Dedicated session lineage tab for DSH Web: browse the current root, fork, and subagent family as a bounded tree and click any node to navigate.
+- [dsh-session-tree](https://github.com/ZhengQingJing/dsh-session-tree) - Read-only session lineage tab for DSH Web: browse the current root, fork, and subagent family as a bounded tree and click any node to navigate.
 - [chouyong/dsh-branch-review](https://github.com/chouyong/dsh-branch-review) - Track human decisions for related DSH session branches: keep, discard, or follow up with reasons, labels, and external links.
 - [dsh-fork-diff](https://github.com/chouyong/dsh-fork-diff) - Read-only parent and sibling branch comparison in DSH Web: message and tool diffs, usage and latency summaries, filters, and open-session navigation.
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - Token usage statistics as a Settings page: cumulative KPIs, a six-month activity heatmap, stacked per-model daily bars and a model donut, rescanned read-only from session logs.

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Management panel: Settings → Plugins.
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - Pin assistant replies from the Web action strip and recall them into the next model turn (`/pin` `/recall`, with optional wake).
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn navigation plugin.
 - [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - Git-style conversation fork graph in the session header: colored lanes and fork curves show which session branched from which, with click-to-jump navigation.
+- [dsh-session-tree](https://github.com/ZhengQingJing/dsh-session-tree) - Dedicated session lineage tab for DSH Web: browse the current root, fork, and subagent family as a bounded tree and click any node to navigate.
 - [chouyong/dsh-branch-review](https://github.com/chouyong/dsh-branch-review) - Track human decisions for related DSH session branches: keep, discard, or follow up with reasons, labels, and external links.
 - [dsh-fork-diff](https://github.com/chouyong/dsh-fork-diff) - Read-only parent and sibling branch comparison in DSH Web: message and tool diffs, usage and latency summaries, filters, and open-session navigation.
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - Token usage statistics as a Settings page: cumulative KPIs, a six-month activity heatmap, stacked per-model daily bars and a model donut, rescanned read-only from session logs.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -259,6 +259,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - 在 Web 助手消息操作条钉住回复，再通过 `/pin` `/recall` 召回进下一轮模型上下文（可一键唤醒）。
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn 导航插件。
 - [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - 会话标题栏内联的 Git 风格 fork 血缘图：用彩色轨道与分叉曲线显示会话从何处分支，并可点击跳转。
+- [dsh-session-tree](https://github.com/ZhengQingJing/dsh-session-tree) - DSH Web 的专用会话谱系标签页：以有界树展示当前根会话、分支与子代理家族，并可点击节点跳转。
 - [chouyong/dsh-branch-review](https://github.com/chouyong/dsh-branch-review) - 为相关 DSH 会话分支记录人工决策：保留、淘汰或待跟进，并保存理由、标签与外部链接。
 - [dsh-fork-diff](https://github.com/chouyong/dsh-fork-diff) - DSH Web 的只读父分支与兄弟分支比较：展示消息与工具差异、用量与耗时摘要，支持筛选和打开对应会话。
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - 设置页 Token 用量统计：累计 KPI、半年活跃热力图、按模型堆叠的每日柱状图与模型环形图，只读重算会话日志。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -259,7 +259,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pin-recall](https://github.com/kerwin2046/dsh-pin-recall) - 在 Web 助手消息操作条钉住回复，再通过 `/pin` `/recall` 召回进下一轮模型上下文（可一键唤醒）。
 - [dsh-turn-navigator](https://github.com/dsh-external/dsh-turn-navigator) - DSH Web turn 导航插件。
 - [dsh-fork-graph](https://github.com/chouyong/dsh-fork-graph) - 会话标题栏内联的 Git 风格 fork 血缘图：用彩色轨道与分叉曲线显示会话从何处分支，并可点击跳转。
-- [dsh-session-tree](https://github.com/ZhengQingJing/dsh-session-tree) - DSH Web 的专用会话谱系标签页：以有界树展示当前根会话、分支与子代理家族，并可点击节点跳转。
+- [dsh-session-tree](https://github.com/ZhengQingJing/dsh-session-tree) - DSH Web 的只读会话谱系标签页：以有界树展示当前根会话、分支与子代理家族，并可点击节点跳转。
 - [chouyong/dsh-branch-review](https://github.com/chouyong/dsh-branch-review) - 为相关 DSH 会话分支记录人工决策：保留、淘汰或待跟进，并保存理由、标签与外部链接。
 - [dsh-fork-diff](https://github.com/chouyong/dsh-fork-diff) - DSH Web 的只读父分支与兄弟分支比较：展示消息与工具差异、用量与耗时摘要，支持筛选和打开对应会话。
 - [dsh-usage-panel](https://github.com/AlfredChaos/dsh-usage-panel) - 设置页 Token 用量统计：累计 KPI、半年活跃热力图、按模型堆叠的每日柱状图与模型环形图，只读重算会话日志。


### PR DESCRIPTION
## Summary

- Adds dsh-session-tree to **Dashboards & Session UX**.
- Adds matching factual descriptions to the English and Simplified Chinese lists.

## Why it is distinct

Unlike the existing header-lane dsh-fork-graph entry, dsh-session-tree provides a dedicated read-only bounded tree tab that includes root, fork, and subagent lineage with click-to-navigate. Branch creation remains owned by native DSH.

## Project

- Repository: https://github.com/ZhengQingJing/dsh-session-tree
- npm: https://www.npmjs.com/package/dsh-session-tree
- License: MIT
- Topics: dsh, dsh-plugin, deepseek-harness

## Current compatibility

- dsh-session-tree: 0.2.0-beta.1
- DeepSeek Harness: 0.1.0-rc.7
- Install: `dsh plugin --profile web add dsh-session-tree@0.2.0-beta.1`

Only README.md and README.zh-CN.md are changed; CATALOG.md remains generated by the repository workflow.
