### PR TITLE
docs: add dsh-univer-office with Office & Documents category

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 - [Git & Engineering](#git--engineering)
 - [Security & Governance](#security--governance)
 - [Output & Deliverables](#output--deliverables)
+- [Office & Documents](#office--documents)
 - [Notifications & Channels](#notifications--channels)
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Plugin Ecosystem & Development](#plugin-ecosystem--development)
@@ -484,6 +485,10 @@ Management panel: Settings → Plugins.
 - [dsh-translate](https://github.com/PerryLink/dsh-translate) - Vendor parameter translation and deterministic JSON repair for DeepSeek Harness: a /translate command maps 13 canonical parameters across 11 vendors, and the post-execute repair layer (plus fix_json) fixes broken JSON tool output without fabricating data.
 - [inspiration-deck-workshop](https://github.com/zjsthmjialin/inspiration-deck-workshop) - Registers the Inspiration Deck Workshop skill: local static HTML presentation decks (6 deck templates, 25+ layouts, themes & motion showroom) with a validate + PNG/PDF export CLI, zero runtime deps.
 - [pdf-background-gray-codex-skill](https://github.com/zjsthmjialin/pdf-background-gray-codex-skill) - Whitens gray/off-white scan backgrounds in image-based PDFs while preserving resolution, page geometry and anti-aliased text edges (lossless Flate write-back) via a single Python script.
+
+## Office & Documents
+
+- [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - Create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases in DeepSeek Harness, with live preview and worktree review.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,6 +46,7 @@
 - [Git & Engineering](#git--engineering)
 - [Security & Governance](#security--governance)
 - [Output & Deliverables](#output--deliverables)
+- [Office & Documents](#office--documents)
 - [Notifications & Channels](#notifications--channels)
 - [Fun & Lifestyle](#fun--lifestyle)
 - [Plugin Ecosystem & Development](#plugin-ecosystem--development)
@@ -483,6 +484,10 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [inspiration-deck-workshop](https://github.com/zjsthmjialin/inspiration-deck-workshop) - 注册灵感演示工坊技能：本地静态 HTML 演示文稿（6 套 deck 模板、25+ 布局、主题与动效展示馆），带 validate 校验与 PNG/PDF 导出 CLI，零运行时依赖。
 - [pdf-background-gray-codex-skill](https://github.com/zjsthmjialin/pdf-background-gray-codex-skill) - 去除扫描 PDF 的灰色/米白底色，保持分辨率、页面几何与抗锯齿文字边缘（无损 Flate 写回），核心为单文件 Python 脚本。
 - [JohnXu22786/docgen](https://github.com/JohnXu22786/docgen) - 文档工坊技能包：纯提示词（Agent Skills）文档生成——README、PR 描述、changelog 与代码审查；零第三方依赖。
+
+## Office & Documents
+
+- [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - 在 DeepSeek Harness 中创建、编辑、检查和交付表格、文档、演示文稿、多维表格和画布，支持实时预览与 worktree 审阅。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
# Add Office & Documents category with dsh-univer-office

## Summary

Adds a new **Office & Documents** category and adds [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) to both `README.md` and `README.zh-CN.md`.

## Why a new category

The existing categories do not closely fit an Office/Documents bundle:

- `Output & Deliverables` is mostly reports/export/artifact tooling.
- `Tools & Utilities` is mostly small standalone utilities.
- `Input & Editing` is mostly composer/input/file-upload tooling.
- `Core & Bundles` is for foundational/core bundles, but this is specifically an office capability bundle.

`dsh-univer-office` is the Univer office plugin for DeepSeek Harness: create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases, with live preview and worktree-based review.

## Changes

- Add `Office & Documents` section to `README.md`
- Add `Office & Documents` section to `README.zh-CN.md`
- Update the Contents list in both files
- Add `dream-num/dsh-univer-office` to both language versions

## Checklist

- [x] Real repository, real code, no placeholder
- [x] One-line factual description in both English and Chinese
- [x] `dsh.bundle` manifest declared in `package.json`
- [x] `dsh-plugin` GitHub topic enabled
- [x] Installable via `dsh plugin --profile web add dsh-univer-office`
