### PR TITLE
docs: refresh DeepSeek Harness Handbook tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -682,7 +682,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue aggregation hub.
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual.
-- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - Agent-first, source-backed guide to running, extending, and troubleshooting DSH, with multilingual navigation and a downloadable field guide.
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 79 source-backed guides for running, extending, and troubleshooting DSH, plus a local-browser [Install Doctor](https://sandbaseai.github.io/deepseek-harness-handbook/install-doctor.html) and [Failure Router](https://sandbaseai.github.io/deepseek-harness-handbook/diagnose.html).
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI-compatible endpoint with free DeepSeek V4 Pro/Flash daily quotas; point DEEPSEEK_BASE_URL at it, no payment info required.
 - [DeepSeek](https://deepseek.com) - Official site.
 


### PR DESCRIPTION
Updates the existing Handbook entry accepted in #118 without adding a duplicate.

The project has grown to 79 English-canonical, source-backed guides and now ships two local-browser operator tools:

- Install Doctor generates OS/install-path-specific evidence commands and success signals.
- Failure Router maps the first failure to the relevant runtime boundary and guide.

Both links are public GitHub Pages artifacts and do not upload logs or configuration. The change is limited to the existing single catalog line.