### PR TITLE
docs: add Sandbase DSH plugin store

### DIFF
--- a/README.md
+++ b/README.md
@@ -562,6 +562,7 @@ Management panel: Settings → Plugins.
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - Generate Functions, MCP tools, workflow Skills, and offline test packages from user-authorized source code.
 - [dsh-movein](https://github.com/sjh9714/dsh-movein) - Move a whole Claude Code setup into DSH in one command: skills, MCP servers, hooks, subagents and permission rules, with a dry-run moving estimate, a migration diff report, and a movein_from_claude_code agent tool.
 - [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - Verified SKILL.md catalog and installer with 88 installable skill bundles for DSH and compatible agents.
+- [dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) - Native DSH Settings marketplace for browsing the community catalog by search and tags, installing plugins, and reviewing installed packages.
 - [DshMarketPlace/dsh-plugins-store](https://github.com/DshMarketPlace/dsh-plugins-store) - In-DSH bilingual plugin catalogue: `/store`, a Settings tab, agent search/install tools, a bundled discovery skill, and risk-aware approval before installation.
 - [dsh-hmz](https://github.com/dsh-external/dsh-hmz) - Placeholder repository; description pending.
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - Interpreter plugin (cordis).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -561,6 +561,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [Code2Skill](https://github.com/leechen298/Code2Skill) - 从用户授权的源码生成 Function、MCP 工具、工作流 Skill 与离线测试包。
 - [dsh-movein](https://github.com/sjh9714/dsh-movein) - 一条命令把整套 Claude Code 配置迁入 DSH：技能、MCP 服务器、hooks、子代理与权限规则，附 dry-run 迁移清单、迁移差异报告与 movein_from_claude_code 工具。
 - [sandbase-skills](https://github.com/sandbaseai/sandbase-skills) - 经校验的 SKILL.md 目录与安装器，为 DSH 和兼容 Agent 提供 88 个可安装技能包。
+- [dsh-plugin-store](https://github.com/sandbaseai/dsh-plugin-store) - DSH 设置页原生插件市场，支持按搜索和标签浏览社区目录、安装插件并查看已安装包。
 - [DshMarketPlace/dsh-plugins-store](https://github.com/DshMarketPlace/dsh-plugins-store) - 装在 DSH 内的双语插件目录：提供 `/store`、设置页、Agent 搜索/安装工具和随包发现 Skill，并在安装前展示风险项、请求确认。
 - [dsh-hmz](https://github.com/dsh-external/dsh-hmz) - 占位仓库，描述待补充。
 - [dsh-interpreters](https://github.com/dsh-external/dsh-interpreters) - 解释器插件（cordis）。


### PR DESCRIPTION
## Summary

Add sandbaseai/dsh-plugin-store to the bilingual Plugin Ecosystem & Development section.

The entry is intentionally factual and limited to the current feature set:

- native DSH Settings integration
- community catalog search and tag filtering
- plugin installation
- installed-package view

## Verification

- The repository declares dsh.bundle.patch and a Web client manifest.
- Host and Web client build artifacts are committed in the preview release.
- English and Chinese lists were updated together.
- git diff --check passes.

Project: https://github.com/sandbaseai/dsh-plugin-store
Preview release: https://github.com/sandbaseai/dsh-plugin-store/releases/tag/v0.1.0-preview.2