### PR TITLE
Add wooden-fish overlay to Fun & Lifestyle documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,6 +557,7 @@ Management panel: Settings → Plugins.
 - [dsh-weather](https://github.com/sunshine-lang/dsh-weather) - Weather tool: current conditions and multi-day forecasts via Open-Meteo (free, no API key).
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF toolbox: extract text, metadata, and page ranges via pdfjs-dist (local, no API key).
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - Pixel whale companion (blink/tail/spout/hearts).
+- [dsh-muyu](https://github.com/liuwenji007/dsh-muyu) - Wooden-fish overlay in the Web client's lower-right: knock the whale for per-session merit; auto-knocks while the model thinks or streams.
 - [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - Desktop whale pet with live session state.
 - [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) - macOS desk pet in a real always-on-top window rather than a page widget: six states from local DSH, native right-click menu, and a bundled skill that turns one photo into a full eighteen-pose skin.
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - Desktop pet, Rust edition.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -556,6 +556,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-weather](https://github.com/sunshine-lang/dsh-weather) - 天气工具：实时天气与多日预报，数据来自 Open-Meteo（免费，无需 API key）。
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF 工具箱：基于 pdfjs-dist 提取文本、元数据与页码范围（本地解析，无需 API key）。
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - 像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）
+- [dsh-muyu](https://github.com/liuwenji007/dsh-muyu) - Web 右下角电子木鱼：点头记本会话功德；模型思考或流式输出时会自动敲。
 - [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - 桌面小鲸鱼，实时感知会话状态
 - [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) - 用真的置顶窗口而不是页面挂件实现的 macOS 桌宠：六种状态跟着本地 DSH 走，原生右键菜单，自带的 skill 把一张照片变成整套十八个姿势的皮肤。
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - 桌宠 Rust 版


### PR DESCRIPTION
This pull request updates the plugin documentation in both the English and Chinese README files to add a new plugin, `dsh-muyu`, which provides a wooden-fish overlay feature in the web client.

**Plugin documentation updates:**

* Added `dsh-muyu` to the English plugin list in `README.md`, describing it as a wooden-fish overlay in the web client's lower-right corner, which allows users to "knock the whale" for per-session merit and auto-knocks while the model processes or streams.
* Added `dsh-muyu` to the Chinese plugin list in `README.zh-CN.md`, describing it as an electronic wooden-fish in the lower-right of the web interface, tracking session merit and auto-knocking during model thinking or streaming.List the wooden-fish overlay in Fun & Lifestyle so people waiting on loops can find it.