### PR TITLE
Add DeepSeek Harness Ultimate curated profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Management panel: Settings → Plugins.
 
 ## Core & Bundles
 
+- [DeepSeek Harness Ultimate](https://github.com/18126295767-cell/deepseek-harness-ultimate) - Community-maintained reproducible profile installer: deduplicated defaults across coding, workflow, reliability and productivity; full commit-SHA pins, permissive-license audit, pre/post dependency checks, optional sensitive integrations, and beginner guides in 20 languages for Windows, macOS and Linux.
 - [dsh-deepresearch](https://github.com/dsh-external/dsh-deepresearch) - DeepResearch plugin (cordis).
 - [dsh-plan-execute](https://github.com/dsh-external/dsh-plan-execute) - Dual-model plan/execute routing: planner model thinks, executor model acts.
 - [dsh-toolkit](https://github.com/dsh-external/dsh-toolkit) - Zero-dependency tool suite (calculator/csv/diff/encoding/json/markdown/regex/time).


### PR DESCRIPTION
Adds a community-maintained curated profile installer for users who want a reproducible baseline rather than choosing overlapping plugins one by one.

The entry describes only repository-verifiable behavior: full upstream commit pins, recorded permissive licenses, dependency audits, non-overlapping defaults, optional sensitive integrations, and paired beginner documentation in 20 languages. The project identifies itself as unofficial and preserves upstream ownership and notices.