### PR TITLE
docs: add dsh-skill-migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Management panel: Settings → Plugins.
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic workflow for DSH (placeholder).
 - [dsh-equip-engine](https://github.com/wuykjl/dsh-equip-engine) - Task-driven plugin equip engine: dual retrieval (curated rules + LLM semantic), combo scoring (synergy/conflict/cost/trust), conflict detection and install-command export.
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) - Four-source migration wizard: move Claude Code, Codex, OpenCode and Hermes sessions, memories, skills, instructions and slash commands into DSH (approval-gated, idempotent, resumable sessions).
-- [dsh-skill-migrator](https://github.com/mjylfz/dsh-skill-migrator) - One-click skill migration into DSH: scans 14 agent platforms (Cursor, Claude Code, Codex, Hermes, Trae, Qoder...) plus the shared ~/.agents layer, merges same-name skills, dedupes symlinks and rolls back safely.
+- [dsh-skill-mover](https://github.com/mjylfz/dsh-skill-mover) - One-click skill migration into DSH: scans 14 agent platforms (Cursor, Claude Code, Codex, Hermes, Trae, Qoder...) plus the shared ~/.agents layer, merges same-name skills, dedupes symlinks and rolls back safely.
 - [gewu-tools](https://github.com/nyantused-cpun/gewu-tools) - Model-agnostic visual-inspection pipeline for text-only agents: page-by-page HTML screenshots plus a ready-made vision-subagent briefing contract (gewu_prep), then source-code truth verification of every finding (gewu_locate); validated on mimo-v2.5 & qwen3.7-plus.
 
 ## Agents & Orchestration

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Management panel: Settings → Plugins.
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic workflow for DSH (placeholder).
 - [dsh-equip-engine](https://github.com/wuykjl/dsh-equip-engine) - Task-driven plugin equip engine: dual retrieval (curated rules + LLM semantic), combo scoring (synergy/conflict/cost/trust), conflict detection and install-command export.
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) - Four-source migration wizard: move Claude Code, Codex, OpenCode and Hermes sessions, memories, skills, instructions and slash commands into DSH (approval-gated, idempotent, resumable sessions).
+- [dsh-skill-migrator](https://github.com/mjylfz/dsh-skill-migrator) - One-click skill migration into DSH: scans 14 agent platforms (Cursor, Claude Code, Codex, Hermes, Trae, Qoder...) plus the shared ~/.agents layer, merges same-name skills, dedupes symlinks and rolls back safely.
 - [gewu-tools](https://github.com/nyantused-cpun/gewu-tools) - Model-agnostic visual-inspection pipeline for text-only agents: page-by-page HTML screenshots plus a ready-made vision-subagent briefing contract (gewu_prep), then source-code truth verification of every finding (gewu_locate); validated on mimo-v2.5 & qwen3.7-plus.
 
 ## Agents & Orchestration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,6 +87,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic Workflow for dsh（占位）。
 - [dsh-equip-engine](https://github.com/wuykjl/dsh-equip-engine) - 任务驱动插件配装引擎：双路检索（人工精选规则 + LLM 语义）、组合评分（协同/冲突/成本/信任）、冲突检测与安装命令导出。
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) - 四合一迁移向导：把 Claude Code、Codex、OpenCode、Hermes 的会话、记忆、技能、指令与斜杠命令迁入 DSH（审批门 + 幂等，会话可续聊）。
+- [dsh-skill-migrator](https://github.com/mjylfz/dsh-skill-migrator) - 技能一键迁移：扫描 14 个 Agent 平台（Cursor、Claude Code、Codex、Hermes、Trae、Qoder 等）与共享层 ~/.agents，同名技能合并、软链接去重、可安全回滚。
 - [gewu-tools](https://github.com/nyantused-cpun/gewu-tools) - 面向纯文本 DSH 主脑的模型无关视觉审阅流水线：HTML 逐页截图 + 视觉子代理简报契约（gewu_prep），再把每条审阅发现定位回源码核验真值（gewu_locate）；已在 mimo-v2.5 与 qwen3.7-plus 上实测。
 
 ## Agents & Orchestration

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -87,7 +87,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh_workflow](https://github.com/dsh-external/dsh_workflow) - Dynamic Workflow for dsh（占位）。
 - [dsh-equip-engine](https://github.com/wuykjl/dsh-equip-engine) - 任务驱动插件配装引擎：双路检索（人工精选规则 + LLM 语义）、组合评分（协同/冲突/成本/信任）、冲突检测与安装命令导出。
 - [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) - 四合一迁移向导：把 Claude Code、Codex、OpenCode、Hermes 的会话、记忆、技能、指令与斜杠命令迁入 DSH（审批门 + 幂等，会话可续聊）。
-- [dsh-skill-migrator](https://github.com/mjylfz/dsh-skill-migrator) - 技能一键迁移：扫描 14 个 Agent 平台（Cursor、Claude Code、Codex、Hermes、Trae、Qoder 等）与共享层 ~/.agents，同名技能合并、软链接去重、可安全回滚。
+- [dsh-skill-mover](https://github.com/mjylfz/dsh-skill-mover) - 技能一键迁移：扫描 14 个 Agent 平台（Cursor、Claude Code、Codex、Hermes、Trae、Qoder 等）与共享层 ~/.agents，同名技能合并、软链接去重、可安全回滚。
 - [gewu-tools](https://github.com/nyantused-cpun/gewu-tools) - 面向纯文本 DSH 主脑的模型无关视觉审阅流水线：HTML 逐页截图 + 视觉子代理简报契约（gewu_prep），再把每条审阅发现定位回源码核验真值（gewu_locate）；已在 mimo-v2.5 与 qwen3.7-plus 上实测。
 
 ## Agents & Orchestration


### PR DESCRIPTION
## What

Add [dsh-skill-migrator](https://github.com/mjylfz/dsh-skill-migrator) to the **Core & Bundles** category (both EN and zh-CN READMEs).

## Why

One-click migration of Agent skills into DeepSeek Harness:

- Scans **14 agent platforms** (Cursor / Claude Code / Codex / OpenCode / Hermes / OpenClaw / Kimi / Trae / Trae CN / CodeBuddy / Qwen Code / Qoder / Qoder CN / QoderWork) plus the shared `~/.agents` skills layer (DSH reads it natively)
- Same-name skills across platforms are merged into one group with selectable source; symlink dedup; frontmatter name normalization; rollback support
- All paths verified against official docs/source; details in the repo's research doc
- Related: sits alongside [dsh-claude-move](https://github.com/PerryLink/dsh-claude-move) (session/memory migration) — this one focuses on skills only

Repo carries the `dsh-plugin` topic and is MIT licensed.