### PR TITLE
docs: add dsh-credential-manager and dsh-auto-review (accpowered)

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,8 @@ Management panel: Settings → Plugins.
 - [dsh-perm-guard](https://github.com/a903067276-rgb/dsh-perm-guard) - Auto-approval permission guard: a middle tier between workspace-write and danger-full-access — auto-allows safe operations inside trust directories, always asks a human for destructive ones, with 11 per-category switches and an audit trail.
 - [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - Configurable per-turn budgets that limit distinct files, mutation calls, and UTF-8 payload bytes before supported file-mutation tools run.
 - [JohnXu22786/docgen](https://github.com/JohnXu22786/docgen) - Documentation workshop skill pack: pure-prompt (Agent Skills) doc generation — README, PR description, changelog and code review; zero third-party dependencies.
+- [accpowered/dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager) - Named credential manager: the model uses API keys, tokens, and logins by reference; secret values are injected into each shell run as `DSH_CM_*` env vars, resolved per execution, and never enter the conversation.
+- [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) - LLM auto-review approval answerer for sandbox escalations under the `'auto'` policy: a deterministic filter plus a clean-context reviewer model decide without a human prompt, fail-closed on every error path; requires a patched harness core (included in core-patches/).
 
 ## Output & Deliverables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -490,6 +490,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - 可配置的逐回合修改额度，在受支持的文件修改工具执行前限制不同文件数、修改调用数与 UTF-8 载荷字节数。
 - [JohnXu22786/safety-net](https://github.com/JohnXu22786/safety-net) - 破坏性命令拦截闸门：执行前解析 rm -rf / git reset --hard / push --force 并要求人工确认（dsh 插件 + 通用 CLI）。
 - [JohnXu22786/secret-guard](https://github.com/JohnXu22786/secret-guard) - 阻止 agent 读写敏感文件（.env、凭据），掩码工具结果中泄露的密钥，含审计日志与安全的 sg_* 检查工具。
+- [accpowered/dsh-credential-manager](https://github.com/accpowered/dsh-credential-manager) - 命名凭据管理：模型按引用使用 API key、令牌与登录凭据；秘密值以 `DSH_CM_*` 环境变量按次注入 shell 执行，绝不进入对话。
+- [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) - 沙箱升级请求的 LLM 自动审查审批应答器（`'auto'` 策略下）：确定性过滤 + 清洁上下文审查模型裁决，无需人工提示，错误路径一律 fail-closed；需要打过补丁的 harness 核心（补丁见 core-patches/）。
 
 ## Output & Deliverables
 


### PR DESCRIPTION
Adds two security plugins to **Security & Governance** (both language files updated in this PR, per contributing.md):

- **accpowered/dsh-credential-manager** — named credentials used by reference; secrets injected as `DSH_CM_*` env vars, never entering the conversation. Install-verified on vanilla upstream `@deepseek-ai/dsh@0.1.0-rc.7`.
- **accpowered/dsh-auto-review** — LLM auto-review approval answerer (`'auto'` policy), deterministic filter + clean-context reviewer, fail-closed; requires the patched harness core included in the repo. Named with the owner prefix to avoid confusion with the already-listed PerryLink/dsh-auto-review, which is a different project.

Both repos carry the `dsh-plugin` topic and ship real code with unit tests.