### PR TITLE
docs: add Chael-Chael/dsh-reference-anything

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Management panel: Settings → Plugins.
 - [dsh-message-edit](https://github.com/dsh-external/dsh-message-edit) - Branch-based message editing / reroll / retry / version timeline.
 - [dsh-prompt-studio](https://github.com/dsh-external/dsh-prompt-studio) - Edit system-prompt sections with live preview.
 - [dsh-paste-input](https://github.com/dsh-external/dsh-paste-input) - Ctrl+V paste files / drag & drop / picker.
+- [dsh-reference-anything](https://github.com/Chael-Chael/dsh-reference-anything) - Extends the native DSH `@` menu with five configurable source groups: commands, skills, workspace files, DSH sessions, and ChatGPT/Claude/Gemini/DeepSeek/Grok/Kimi conversations; external bodies and attachments are read on demand with per-task authorization.
 - [dsh-voice](https://github.com/motongv/dsh-voice) - Voice input (speech-to-text) and read-aloud (Edge neural TTS) for the composer.
 - [dsh-drag-and-drop](https://github.com/dsh-external/dsh-drag-and-drop) - Cross-platform drag & drop with original path insertion.
 - [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) - Upload arbitrary local files from the Web composer, show pending cards, and manage stored files in Settings.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -174,6 +174,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-message-edit](https://github.com/dsh-external/dsh-message-edit) - 分支式消息编辑 / reroll / retry / 版本时间线
 - [dsh-prompt-studio](https://github.com/dsh-external/dsh-prompt-studio) - 系统提示词分段编辑 + 实时预览
 - [dsh-paste-input](https://github.com/dsh-external/dsh-paste-input) - Ctrl+V 粘贴文件 / 拖拽 / 选择
+- [dsh-reference-anything](https://github.com/Chael-Chael/dsh-reference-anything) - 扩展 DSH 原生 `@` 菜单，提供五类可配置来源：命令、Skills、工作区文件、DSH 会话，以及 ChatGPT/Claude/Gemini/DeepSeek/Grok/Kimi 对话；外部正文与附件按需读取，并按任务授权。
 - [dsh-voice](https://github.com/motongv/dsh-voice) - 语音输入（语音转文字）+ 回答朗读（Edge 神经网络音色）
 - [dsh-drag-and-drop](https://github.com/dsh-external/dsh-drag-and-drop) - 跨平台拖拽插入原始路径
 - [dsh-file-uploads](https://github.com/l541402398/dsh-file-uploads) - 从 Web 输入框上传任意本地文件，以待发送卡片展示，并在设置中管理已存文件。


### PR DESCRIPTION
## Summary

Add [dsh-reference-anything](https://github.com/Chael-Chael/dsh-reference-anything) to **Input & Editing** in both the English and Chinese READMEs.

The plugin extends the native DSH `@` menu with five configurable source groups: commands, skills, workspace files, DSH sessions, and external conversations from ChatGPT, Claude, Gemini, DeepSeek, Grok, and Kimi. External conversation bodies and attachments are read on demand with per-task authorization.

## Category

**Input & Editing** is the closest match because the plugin's primary user-facing integration is the native Composer `@` menu. Session and external-conversation retrieval are initiated through references inserted from that menu.

## Verification

- Public working repository with a v0.3.0 release
- Uses the `dsh-plugin` GitHub topic
- MIT licensed
- English and Chinese entries updated together
- Entry descriptions are factual and limited to one line