### PR TITLE
docs: add taltara/capmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,6 +493,7 @@ Management panel: Settings → Plugins.
 - [dsh-perm-guard](https://github.com/a903067276-rgb/dsh-perm-guard) - Auto-approval permission guard: a middle tier between workspace-write and danger-full-access — auto-allows safe operations inside trust directories, always asks a human for destructive ones, with 11 per-category switches and an audit trail.
 - [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - Configurable per-turn budgets that limit distinct files, mutation calls, and UTF-8 payload bytes before supported file-mutation tools run.
 - [JohnXu22786/docgen](https://github.com/JohnXu22786/docgen) - Documentation workshop skill pack: pure-prompt (Agent Skills) doc generation — README, PR description, changelog and code review; zero third-party dependencies.
+- [dsh-capmark-gate](https://github.com/taltara/capmark) - Holds an agent to a declared capability manifest: a Markdown `CAP.md` states what a plugin may do, and the gate masks the agent's tool view with `tools.restrict()` and judges every call at `tools/pre-execute`; scopes finer than a tool name are linted as advisory rather than presented as enforcement.
 
 ## Output & Deliverables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -491,6 +491,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - 可配置的逐回合修改额度，在受支持的文件修改工具执行前限制不同文件数、修改调用数与 UTF-8 载荷字节数。
 - [JohnXu22786/safety-net](https://github.com/JohnXu22786/safety-net) - 破坏性命令拦截闸门：执行前解析 rm -rf / git reset --hard / push --force 并要求人工确认（dsh 插件 + 通用 CLI）。
 - [JohnXu22786/secret-guard](https://github.com/JohnXu22786/secret-guard) - 阻止 agent 读写敏感文件（.env、凭据），掩码工具结果中泄露的密钥，含审计日志与安全的 sg_* 检查工具。
+- [dsh-capmark-gate](https://github.com/taltara/capmark) - 按声明的能力清单约束 agent：用 Markdown 编写的 `CAP.md` 声明插件可做什么，插件据此用 `tools.restrict()` 收窄 agent 可见的工具集，并在 `tools/pre-execute` 上裁决每次调用；比工具名更细的 scope 会被标记为仅供审计，而非当作强制边界。
 
 ## Output & Deliverables
 


### PR DESCRIPTION
Adds one entry to **Security & Governance**, in both language versions.

`dsh-capmark-gate` holds an agent to a capability manifest it declares up front,
rather than matching the shape of a call after it is written. The section's
existing entries scan, match, or approve; this is the declaration side, and it
composes with them - a manifest is a natural source for the rules a matcher
enforces.

The description names the enforcing mechanisms (`tools.restrict()` and
`tools/pre-execute`) rather than claiming a general guarantee, because the
project deliberately does not claim one: it governs what an *agent* may call and
does not sandbox a plugin's own code.

Verified against `@deepseek-ai/dsh` `0.1.0-rc.7`.

- Repository: https://github.com/taltara/capmark
- Format checker on npm: `capmark`
- MIT

`CATALOG.md` is left untouched, since contributing.md says it is generated from
the hub catalog.
