### PR TITLE
Add dsh-agentvalet under Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Management panel: Settings → Plugins.
 - [dsh-change-budget](https://github.com/Raphaelutumn/dsh-change-budget) - Configurable per-turn budgets that limit distinct files, mutation calls, and UTF-8 payload bytes before supported file-mutation tools run.
 - [JohnXu22786/docgen](https://github.com/JohnXu22786/docgen) - Documentation workshop skill pack: pure-prompt (Agent Skills) doc generation — README, PR description, changelog and code review; zero third-party dependencies.
 - [dsh-capmark-gate](https://github.com/taltara/capmark) - Holds an agent to a declared capability manifest: a Markdown `CAP.md` states what a plugin may do, and the gate masks the agent's tool view with `tools.restrict()` and judges every call at `tools/pre-execute`; scopes finer than a tool name are linted as advisory rather than presented as enforcement.
+- [dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet) - Brokered SaaS access: four tools call approved platforms through a credential broker, minting a short-lived assertion per call, so no API key is stored on the machine and every call is owner-approvable, revocable, and audited.
 
 ## Output & Deliverables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -493,6 +493,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [JohnXu22786/safety-net](https://github.com/JohnXu22786/safety-net) - 破坏性命令拦截闸门：执行前解析 rm -rf / git reset --hard / push --force 并要求人工确认（dsh 插件 + 通用 CLI）。
 - [JohnXu22786/secret-guard](https://github.com/JohnXu22786/secret-guard) - 阻止 agent 读写敏感文件（.env、凭据），掩码工具结果中泄露的密钥，含审计日志与安全的 sg_* 检查工具。
 - [dsh-capmark-gate](https://github.com/taltara/capmark) - 按声明的能力清单约束 agent：用 Markdown 编写的 `CAP.md` 声明插件可做什么，插件据此用 `tools.restrict()` 收窄 agent 可见的工具集，并在 `tools/pre-execute` 上裁决每次调用；比工具名更细的 scope 会被标记为仅供审计，而非当作强制边界。
+- [dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet) - 代理式 SaaS 访问：四个工具经凭据代理调用已授权平台，每次调用签发短期断言，机器上不存任何 API key，每次调用都可由所有者审批、撤销并留存审计。
 
 ## Output & Deliverables
 


### PR DESCRIPTION
One entry, added to both `README.md` and `README.zh-CN.md` under **Security & Governance**.

**[dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet)** — four tools that call approved SaaS platforms through a credential broker. A short-lived assertion is minted per call, so no API key is stored on the machine and every call is owner-approvable, revocable, and audited.

It sits beside the guardrails already on this list rather than duplicating them: `dsh-encrypt` protects the key at rest on the machine, `dsh-safeguard` and `dsh-defend` gate what the model is allowed to attempt. This one removes the credential from the machine altogether, so the boundary for a SaaS call becomes whether the owner issues one at all. A sandbox governs the filesystem; it does not govern Slack or Stripe.

Meets the entry standard: real repo, factual one-liner, no badges or blurbs. Published as `@agentvalet/dsh`, MIT, `package.json#dsh.bundle` → `cordis.patch.yml`, harness range `>=0.1.0-rc.5 <0.2.0`. Verified against 0.1.0-rc.7 by installing the packed tarball into a real headless profile — both rows appear in `--dump-config` and all four tools register at runtime.

The Chinese line is my own translation; happy to take a correction if the phrasing is off.