### PR TITLE
docs: add Tabbit-Browser/dsh-tabbit

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ Management panel: Settings → Plugins.
 - [zoahdev/dsh-vision](https://github.com/zoahdev/dsh-vision) - Vision analysis tool: analyze a local image or URL with an OpenAI-compatible vision model.
 - [dsh-click](https://github.com/PerryLink/dsh-click) - Native desktop control for DeepSeek Harness (Windows first): screen_shot, screen_read accessibility trees, click/type/scroll/key, and app launch — approval-gated, never stealing foreground focus.
 - [zoahdev/dsh-browser-use](https://github.com/zoahdev/dsh-browser-use) - Browser Use cloud bridge: run real web tasks (open pages, click, type, fill forms, extract data) through the Browser Use API.
+- [dsh-tabbit](https://github.com/Tabbit-Browser/dsh-tabbit) - Drive the user's Tabbit Browser from DSH via its Browser-owned, task-isolated Playwright CLI (`tabbit-cli`): bundled `tabbit-browser` skill, ≥1.9.0 runtime preflight, region-aware installer download, and persistent named task spaces (no Chrome/Ego/CDP fallback).
 - [dsh-antigravity](https://github.com/LiZhenNet/dsh-antigravity) - Google Antigravity / Cloud Code Assist model provider for DSH with native Web OAuth, real-time quota tracking, and dynamic reasoning effort routing.
 - [JohnXu22786/model-catalog](https://github.com/JohnXu22786/model-catalog) - Model catalog auto-discovery: fetch model listings, pricing and capabilities from OpenAI-compatible API hosts, normalized into ready-to-use config.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -378,6 +378,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [zoahdev/dsh-vision](https://github.com/zoahdev/dsh-vision) - vision_analyze 工具：用 OpenAI 兼容视觉模型分析本地图片或 URL。
 - [dsh-click](https://github.com/PerryLink/dsh-click) - DeepSeek Harness 原生桌面控制（Windows 优先）：截图、无障碍树结构化读取、点击/输入/滚动/按键与应用启动——变更性操作过审批门禁，不抢占前台焦点
 - [zoahdev/dsh-browser-use](https://github.com/zoahdev/dsh-browser-use) - Browser Use 云端桥接：通过 Browser Use API 让 dsh agent 执行真实网页任务（打开页面、点击、输入、填表、提取数据）。
+- [dsh-tabbit](https://github.com/Tabbit-Browser/dsh-tabbit) - 通过 Tabbit 自有、任务隔离的 Playwright CLI（`tabbit-cli`）操控本机 Tabbit 浏览器：随包加载 `tabbit-browser` Skill、正式版 ≥1.9.0 与运行时预检、按系统地区后台下载安装包、持久命名任务空间（不回退到 Chrome/Ego/CDP）。
 - [dsh-antigravity](https://github.com/LiZhenNet/dsh-antigravity) - Google Antigravity / Cloud Code Assist 模型提供者插件：支持 Web OAuth 登录、实时额度同步、精选 11 个 Base 模型与动态思考档位路由。
 - [JohnXu22786/browser-automation](https://github.com/JohnXu22786/browser-automation) - Web Bridge：面向 dsh 的浏览器自动化 MCP 服务器——真实浏览器导航、点击、填表、截图、JS 执行，由无障碍树快照驱动。
 - [JohnXu22786/computer-control](https://github.com/JohnXu22786/computer-control) - 面向 dsh 的桌面控制：屏幕捕获、指针/键盘注入、无障碍树语义操作，紧急停止、允许/拒绝规则、确认流程与空闲待机。

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -1090,6 +1090,7 @@ TOPIC_MANUAL = {
     "NinjaSln-labs/dsh-plugins": "开发与工程",
     "Shmilyol/galgame-skin": "界面与体验",
     "zibo2025/dsh-agent-mesh": "Agent 与自动化",
+    "Tabbit-Browser/dsh-tabbit": "浏览器与远程",
 }
 TOPIC_MANUAL = {k.lower(): v for k, v in TOPIC_MANUAL.items()}
 


### PR DESCRIPTION
List the Tabbit Browser DSH bundle under Browser & Remote in both language versions, and classify it as 浏览器与远程 for the next catalog sync.