### PR TITLE
Add dsh-usage-dashboard to Dashboards & Session UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,6 +326,7 @@ Management panel: Settings → Plugins.
 - [JohnXu22786/session-titler](https://github.com/JohnXu22786/session-titler) - Two-phase session captioning for DeepSeek Harness: instant keyword captions while busy, budget-model refinement when idle.
 - [dsh-billing-tui](https://github.com/Ethanz11-creat/dsh-billing-tui) - Real-time token/cost billing with official DeepSeek peak/off-peak pricing: TUI status line and a whale ASCII receipt via /billing.
 
+- [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) - Peak/valley billing dock and usage analytics: token/cost/model stats, trend and token-mix charts, latest-20-turns records, global time/session/model filters.
 ## IDE & Clients
 
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -325,6 +325,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [JohnXu22786/session-titler](https://github.com/JohnXu22786/session-titler) - 双阶段会话标题生成：忙碌时即时关键词标题，空闲时用经济模型精修。
 - [dsh-billing-tui](https://github.com/Ethanz11-creat/dsh-billing-tui) - 实时 token 计费，按 DeepSeek 官方峰谷定价：TUI 状态行实时显示费用，/billing 打印鲸鱼 ASCII 账单小票。
 
+- [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) - 峰谷计费坞 + 用量分析仪表盘：token/成本/模型统计、成本趋势与 Token 结构图表、最近 20 轮明细，支持时间/会话/模型全局筛选与账户余额。
 ## IDE & Clients
 
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code 风格全屏 TUI（流式展开/双击 Esc 回滚）


### PR DESCRIPTION
Adds **dsh-usage-dashboard** (https://github.com/woosh2010/dsh-usage-dashboard), a DeepSeek Harness usage-analytics plugin, to the Dashboards & Session UX category in both README.md and README.zh-CN.md.

- Peak/valley time-of-use billing dock under the composer (Beijing-time peak 9:00–12:00/14:00–18:00, valley at half price) with live DeepSeek account balance.
- Cross-session local history (`usage-history.jsonl`) with global filters (time range / all vs this session / per model), cost trend, token-mix donut with per-model switch, model distribution, peak-vs-valley, and the latest 20 turns of step-level records.
- Install: `dsh plugin --profile web add https://github.com/woosh2010/dsh-usage-dashboard/releases/download/v0.4.0/deepseek-ai-dsh-client-ui-usage-0.4.0.tgz` (repo has the `dsh-plugin` topic).
- MIT license, docs in 7 languages.