### PR TITLE
docs: add dsh-browser-vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Management panel: Settings → Plugins.
 - [dsh-tabbit](https://github.com/Tabbit-Browser/dsh-tabbit) - Drive the user's Tabbit Browser from DSH via its Browser-owned, task-isolated Playwright CLI (`tabbit-cli`): bundled `tabbit-browser` skill, ≥1.9.0 runtime preflight, region-aware installer download, and persistent named task spaces (no Chrome/Ego/CDP fallback).
 - [dsh-antigravity](https://github.com/LiZhenNet/dsh-antigravity) - Google Antigravity / Cloud Code Assist model provider for DSH with native Web OAuth, real-time quota tracking, and dynamic reasoning effort routing.
 - [JohnXu22786/model-catalog](https://github.com/JohnXu22786/model-catalog) - Model catalog auto-discovery: fetch model listings, pricing and capabilities from OpenAI-compatible API hosts, normalized into ready-to-use config.
+- [dsh-browser-vision](https://github.com/tristan-mcinnis/dsh-browser-vision) - Vision browser tool: drives real Chrome over CDP with browser-use and reads the page with deepseek-v4-flash-vision-exp, so canvas text, text baked into images and values in rendered charts are readable; returns JSON validated against a caller-supplied schema and reports per-run token cost.
 
 ## Models & Inference
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -393,6 +393,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-antigravity](https://github.com/LiZhenNet/dsh-antigravity) - Google Antigravity / Cloud Code Assist 模型提供者插件：支持 Web OAuth 登录、实时额度同步、精选 11 个 Base 模型与动态思考档位路由。
 - [JohnXu22786/browser-automation](https://github.com/JohnXu22786/browser-automation) - Web Bridge：面向 dsh 的浏览器自动化 MCP 服务器——真实浏览器导航、点击、填表、截图、JS 执行，由无障碍树快照驱动。
 - [JohnXu22786/computer-control](https://github.com/JohnXu22786/computer-control) - 面向 dsh 的桌面控制：屏幕捕获、指针/键盘注入、无障碍树语义操作，紧急停止、允许/拒绝规则、确认流程与空闲待机。
+- [dsh-browser-vision](https://github.com/tristan-mcinnis/dsh-browser-vision) - 视觉浏览器工具：以 browser-use 通过 CDP 驱动真实 Chrome，并用 deepseek-v4-flash-vision-exp 读取页面，可识别 canvas 上绘制的文字、图片中烧录的文字与图表中的数值；支持按调用方提供的 JSON Schema 返回结构化结果，并统计每次运行的 token 成本
 
 ## Models & Inference
 


### PR DESCRIPTION
Adds `dsh-browser-vision` to **Browser & Remote**, in both `README.md` and `README.zh-CN.md`.

[tristan-mcinnis/dsh-browser-vision](https://github.com/tristan-mcinnis/dsh-browser-vision) is a browser plugin that drives a real Chrome over CDP with browser-use and reads the page with `deepseek-v4-flash-vision-exp`. That makes canvas text, text baked into images and values in rendered charts readable, none of which exist in the DOM. It also returns JSON validated against a caller-supplied schema and reports per-run token cost.

It differs from the browser entries already listed in that the model looks at the page rather than only reading a DOM or accessibility snapshot. browser-use itself still hard-codes `use_vision = False` for any DeepSeek model, which predates the vision model; the plugin restores it.

Registers `browser_vision_task`, `browser_vision_extract` and `browser_vision_status`. Declares `dsh.bundle.patch`, ships `cordis.patch.yml`, and carries the `dsh-plugin` topic.

Measured on its own offline eval suite (6 cases x 3 attempts per mode):

| mode | passed | vision cases | median | cost |
|---|---|---|---|---|
| `off` | 7/18 | 0/9 | 33.7s | $0.1021 |
| `auto` | 14/18 | 9/9 | 8.3s | $0.0310 |
| `on` | 18/18 | 9/9 | 6.6s | $0.0318 |

Vision is also the cheapest setting: a blind agent spends its whole step budget re-reading a DOM that does not hold the answer, and twenty text steps cost more than one 384-token screenshot.

Checklist:
- [x] Real repository, MIT, CI green on Python 3.11/3.12 and Node 22/24
- [x] One factual line per entry, no badges or blurbs inside the entry
- [x] Correct category (Browser & Remote)
- [x] Both language versions updated in this PR