### PR TITLE
Add dsh-plugin-cloud (DSH Cloud gateway provider)

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Management panel: Settings → Plugins.
 - [JohnXu22786/worktree-mgr](https://github.com/JohnXu22786/worktree-mgr) - Task-isolated Git worktrees for dsh: auto-create, sync and tear down isolated workspaces per task.
 - [JohnXu22786/spec-driven](https://github.com/JohnXu22786/spec-driven) - Keel (龙骨): spec-driven development discipline skill pack — spec-first, verify assumptions, prevent over-engineering and scope creep; skills+tools+templates for dsh.
 - [JohnXu22786/adversarial-review](https://github.com/JohnXu22786/adversarial-review) - Gavel-review: adversarial multi-perspective code review — parallel attack lenses, deterministic static sentinels, cross-lens merge/dedup, severity grading, suppression rules and review history; dsh tools + standalone CLI.
+- [dsh-plugin-cloud](https://github.com/AgentsDanceAI/deepseek-harness-cloud/tree/main/packages/dsh-plugin-cloud) - DSH Cloud gateway provider: device-authorized login writes a multi-model provider row (DeepSeek, GPT, Claude, Gemini and more) into the user config layer; works against the hosted service or a self-hosted deployment.
 
 ## Git & Engineering
 


### PR DESCRIPTION
Adds `dsh-plugin-cloud` under **Models & Inference**. Cordis plugin + one-command setup CLI that connects a stock DeepSeek Harness install to a DSH Cloud gateway (hosted or self-hosted): RFC 8628-style device login, then a dedicated `dsh-llm-pi-ai` instance row written into `$DSH_HOME/cordis.patch.yml` (never touches the user's own rows). Published on npm as `dsh-plugin-cloud`; repo carries the `dsh-plugin` topic. Disclosure: I maintain it.