### PR TITLE
Add dsh-plugin-rollout-scout to Models & Inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ Management panel: Settings → Plugins.
 - [JohnXu22786/worktree-mgr](https://github.com/JohnXu22786/worktree-mgr) - Task-isolated Git worktrees for dsh: auto-create, sync and tear down isolated workspaces per task.
 - [JohnXu22786/spec-driven](https://github.com/JohnXu22786/spec-driven) - Keel (龙骨): spec-driven development discipline skill pack — spec-first, verify assumptions, prevent over-engineering and scope creep; skills+tools+templates for dsh.
 - [JohnXu22786/adversarial-review](https://github.com/JohnXu22786/adversarial-review) - Gavel-review: adversarial multi-perspective code review — parallel attack lenses, deterministic static sentinels, cross-lens merge/dedup, severity grading, suppression rules and review history; dsh tools + standalone CLI.
+- [dsh-plugin-rollout-scout](https://github.com/SpookySandwich/dsh-plugin-rollout-scout) - Detects which conversation model your account is being served: launches concurrent throwaway probe conversations, scores each streaming chain-of-thought by how its paragraphs open, and cancels probes that read as the older model within seconds.
 
 ## Git & Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -441,6 +441,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-local-ai](https://github.com/PerryLink/dsh-local-ai) - Ollama 本地模型接入：ollama_list/pull/remove/show 与健康检查，以官方 LlmAdapter 注册 Ollama 路由与 model_route 分流（离线优先/长文本/隐私），失败回退云端；/ollama 命令一键总览。
 - [rapid-mlx-dsh-provider](https://github.com/raullenchai/rapid-mlx-dsh-provider) - Rapid-MLX（Apple 芯片本地推理服务）原生 provider：注册 `rapid-mlx` 的 LlmAdapter 路由，从服务端 `/v1/models` 读取模型信息（上下文窗口、推理解析器、能力）而非手写 settings.yaml，切换所服务的模型无需重新配置，且上下文压缩按真实上下文窗口计时。
 - [JohnXu22786/model-catalog](https://github.com/JohnXu22786/model-catalog) - 模型目录自动发现：从 OpenAI 兼容的 API 主机获取模型列表、价格与能力，归一化为可直接使用的配置。
+- [dsh-plugin-rollout-scout](https://github.com/SpookySandwich/dsh-plugin-rollout-scout) - 检测账号当前被分配到哪个对话模型：并发发起一次性探测会话，按段落开头的写法为流式思维链打分，读起来像旧模型的在数秒内中止。
 
 ## Git & Engineering
 


### PR DESCRIPTION
One entry, appended to **Models & Inference** in both `README.md` and `README.zh-CN.md` — same entry, translated description. The diff is +1 line in each file; nothing else is touched.

Providers sometimes roll a new conversation model out to a subset of accounts, and there is no way to ask which one you got. This launches concurrent throwaway probe conversations, reads each one's chain-of-thought as it streams, and scores it on how its paragraphs open. Probes that read as the older model are cancelled within a second or two, so a run that finds nothing costs very little.

Real repository, MIT, no dependencies. `package.json` declares `dsh.bundle` and `cordis.patch.yml` is committed, as is the built `lib/client.js`, so a `github:` install needs no build step. `dsh-plugin` topic set.