### PR TITLE
docs: add SpookySandwich/dsh-plugin-message-edit

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.
 - [dsh-message-edit](https://github.com/dsh-external/dsh-message-edit) - Branch-based message editing / reroll / retry / version timeline.
+- [SpookySandwich/dsh-plugin-message-edit](https://github.com/SpookySandwich/dsh-plugin-message-edit) - Edit a sent message to rewind and branch the conversation from that turn; version counter under the bubble, a turn-level version tree of the whole branch family, and ChatGPT / DeepSeek / Claude control layouts.
 - [dsh-prompt-studio](https://github.com/dsh-external/dsh-prompt-studio) - Edit system-prompt sections with live preview.
 - [dsh-paste-input](https://github.com/dsh-external/dsh-paste-input) - Ctrl+V paste files / drag & drop / picker.
 - [dsh-reference-anything](https://github.com/Chael-Chael/dsh-reference-anything) - Extends the native DSH `@` menu with five configurable source groups: commands, skills, workspace files, DSH sessions, and ChatGPT/Claude/Gemini/DeepSeek/Grok/Kimi conversations; external bodies and attachments are read on demand with per-task authorization.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -180,6 +180,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - better-sidebar 的 Office 集成。
 - [dsh-message-edit](https://github.com/dsh-external/dsh-message-edit) - 分支式消息编辑 / reroll / retry / 版本时间线
+- [SpookySandwich/dsh-plugin-message-edit](https://github.com/SpookySandwich/dsh-plugin-message-edit) - 编辑已发送的消息即可从该轮次回溯并分叉对话；气泡下方提供版本计数器，「版本」标签页以轮次级树展示整个版本家族，控件布局可选 ChatGPT / DeepSeek / Claude。
 - [dsh-prompt-studio](https://github.com/dsh-external/dsh-prompt-studio) - 系统提示词分段编辑 + 实时预览
 - [dsh-paste-input](https://github.com/dsh-external/dsh-paste-input) - Ctrl+V 粘贴文件 / 拖拽 / 选择
 - [dsh-reference-anything](https://github.com/Chael-Chael/dsh-reference-anything) - 扩展 DSH 原生 `@` 菜单，提供五类可配置来源：命令、Skills、工作区文件、DSH 会话，以及 ChatGPT/Claude/Gemini/DeepSeek/Grok/Kimi 对话；外部正文与附件按需读取，并按任务授权。


### PR DESCRIPTION
Adds one entry to **Input & Editing** in both `README.md` and `README.zh-CN.md`. Pure insertion — two added lines, nothing else touched. `CATALOG.md` left alone since it is generated.

- Repository: https://github.com/SpookySandwich/dsh-plugin-message-edit
- npm `dsh-plugin-message-edit@1.0.0`, MIT, `dsh.bundle.patch` declared and committed.
- Exercised against dsh 0.1.1-rc.2.

Placed directly under the existing `dsh-message-edit` line because the two are adjacent in purpose. This is an independent implementation; what distinguishes it is the turn-level version tree across the whole branch family. Its host code credits Moeblack's plugin (MIT) for the branch-transaction shape and uses a distinct route, cordis id and event type so both can be installed at once.