### PR TITLE
Add dsh-dispatch to Browser & Remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,7 @@ Management panel: Settings → Plugins.
 - [dsh-ssh](https://github.com/jmcc-guo/dsh-ssh) - AI-managed SSH connections with a live multi-tab terminal panel for DeepSeek Harness.
 - [dsh-lan-access](https://github.com/Leon0555/dsh-lan-access) - LAN access for the Web GUI: 0.0.0.0 bind plus a crypto.randomUUID polyfill for non-secure (LAN HTTP) contexts (npm: dsh-lan-access).
 - [xgone/dsh-remote](https://github.com/xgone/dsh-remote) - Remote access & authentication for DeepSeek Harness web UI: account/password login gate, MFA (TOTP), signed session cookies, role-based access, in-browser directory picker, and a Settings page for account management (npm: @xgone/dsh-remote).
+- [dsh-dispatch](https://github.com/alextangson/dsh-dispatch) - Phone-side command center (plugin + zero-knowledge relay + PWA): dispatch tasks into isolated git worktrees from your phone, approval push notifications with phone/desktop first-answer-wins (never auto-approved), and a multi-machine session board; E2E encrypted, self-hostable.
 - [ego-browser](https://github.com/dsh-external/ego-browser) - Browser agent.
 - [dsh-webbridge](https://github.com/dsh-external/dsh-webbridge) - Web bridge.
 - [browser4-dsh](https://github.com/dsh-external/browser4-dsh) - Browser4 AI-native browser engine (skills).


### PR DESCRIPTION
Adds [dsh-dispatch](https://github.com/alextangson/dsh-dispatch) — phone-side command center for dsh: dispatch tasks into isolated git worktrees, tool-approval push notifications (never auto-approved), multi-machine board. E2E encrypted, zero-knowledge self-hostable relay. Plugin + relay + PWA, MIT. Unlike the existing remote entries it doesn't proxy the Web UI — it drives the approval/request waterfall and ctx.agents.create directly. Verified end-to-end on dsh 0.1.1-rc.2 with the real DeepSeek API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)