### PR TITLE
docs: add dsh-sonarqube

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-radar](https://github.com/dsh-external/dsh-plugin-radar) - Daily DSH plugin compatibility radar, renamed from dsh-external-research.
 - [dsh-scout](https://github.com/dsh-external/dsh-scout) - Scout plugin (cordis).
 - [dsh-share](https://github.com/dsh-external/dsh-share) - Share DSH conversations.
-- [dsh-sonar](https://github.com/dsh-external/dsh-sonar) - Sonar plugin (cordis).
+- [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) - Read-only SonarQube Community Build integration for Quality Gates, issues, Security Hotspots, coverage, and project measures, with source file and line locations.
 - [plugin-registry](https://github.com/dsh-external/plugin-registry) - Plugin console + make-dsh-plugin skill + dev guide.
 - [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) - Offline-tolerant registry that discovers and deduplicates DSH plugins from awesome lists, GitHub topics, and npm.
 - [marisa](https://github.com/dsh-external/marisa) - External plugin manager (parasitic install/CLI/settings panel).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -639,7 +639,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-plugin-radar](https://github.com/dsh-external/dsh-plugin-radar) - DSH 插件兼容性雷达，原 dsh-external-research 改名。
 - [dsh-scout](https://github.com/dsh-external/dsh-scout) - scout 插件（cordis）。
 - [dsh-share](https://github.com/dsh-external/dsh-share) - DSH 对话分享插件。
-- [dsh-sonar](https://github.com/dsh-external/dsh-sonar) - sonar 插件（cordis）。
+- [maxmilian/dsh-sonarqube](https://github.com/maxmilian/dsh-sonarqube) - 唯读 SonarQube Community Build 集成：查询 Quality Gate、Issue、Security Hotspot、覆盖率与项目指标，并提供源文件及行号定位。
 - [plugin-registry](https://github.com/dsh-external/plugin-registry) - 插件控制台 + make-dsh-plugin skill + 开发指引
 - [dsh-plugin-manager-registry](https://github.com/Jesse-njx/dsh-plugin-manager-registry) - 离线容错的插件注册表，聚合并去重 awesome 列表、GitHub Topic 与 npm 中的 DSH 插件。
 - [marisa](https://github.com/dsh-external/marisa) - 外部插件管理器（寄生安装/CLI/设置页面板）


### PR DESCRIPTION
Adds maxmilian/dsh-sonarqube to the bilingual curated list. The plugin provides read-only SonarQube Community Build tools for Quality Gates, issues, Security Hotspots, coverage, and project measures, including source file and line locations. This replaces the inaccessible dsh-external/dsh-sonar entry with a public, installable repository.