### PR TITLE
docs: add liustack/modlens vision plugin to Input & Editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Management panel: Settings → Plugins.
 ## Input & Editing
 
 - [dsh-global-rules](https://github.com/Semidia/dsh-global-rules) - Edit your `~/.dsh/AGENTS.md` global rules from the Settings page: a text editor with save button, no command line needed.
+- [liustack/modlens](https://github.com/liustack/modlens) - Vision plugin for text-only LLMs: paste images for recognition, multi-image Q&A, screenshot capture, and visual task completion with one-line install.
 - [Zhangbo-cn/dsh-voice-input-plugin](https://github.com/Zhangbo-cn/dsh-voice-input-plugin) - Composer mic for the Web UI: tap-to-monitor live transcription and hold-to-talk, with host Edge TTS reply reading that streams while the model generates, echo-pause during reading, and tap-to-stop.
 
 - [dsh-better-sidebar-plugin-office](https://github.com/dsh-external/dsh-better-sidebar-plugin-office) - Office integration for DSH-better-sidebar.


### PR DESCRIPTION
## Summary

Add [liustack/modlens](https://github.com/liustack/modlens) to the Input & Editing section.

## About modlens

- Stars: 3574
- The first vision plugin for DeepSeek Harness
- Vision bridge for text-only coding agents
- Features: OCR, layout analysis, semantic understanding, multi-image Q&A, screenshot capture
- One-line install

## Checklist

- [x] Entry added in alphabetical order
- [x] Description is factual and terse
- [x] Link is valid (repository exists and is public)