### PR TITLE
docs: add dsh-blackjack

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ Management panel: Settings → Plugins.
 - [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe) - Steam-style plugin marketplace: subscribe on the web, sync with one command into a dsh profile; 500+ community plugins with verified curation and a zero-dependency CLI.
 - [dsh-vibe-pack](https://github.com/LeemanCheung/dsh-vibe-pack) - Transactional data-only configuration pack manager with integrity, ownership, preview, diff, and rollback safeguards.
 - [Luaphes/dsh-plugins-market](https://github.com/Luaphes/dsh-plugins-market) - Plugin market inside the DSH Web UI: crawls the dsh-plugin topic with noise filtering, curated marks, ranking and one-click install (dsh.bundle-verified).
+- [dsh-blackjack](https://github.com/yul761/dsh-blackjack) - Blackjack in the conversation: free daily hands win CHIP, redeemable one-way into model credit that a fallback route spends only when your own provider quota runs out; operator-funded pool, with the server and its audited ledger open source in the same repo.
 
 ## Plugin Ecosystem & Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -631,6 +631,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-vibe-pack](https://github.com/LeemanCheung/dsh-vibe-pack) - 仅数据的事务式配置包管理器，提供完整性、归属、预览、差异和回滚保护。
 - [Luaphes/dsh-plugins-market](https://github.com/Luaphes/dsh-plugins-market) - DSH Web UI 内插件市场：全量嗅探 dsh-plugin topic，过滤蹭标签噪音，保留人工精选标记，支持排序/搜索/语言过滤与一键安装（安装前校验 dsh.bundle 声明）。
 - [dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) - 钢琴演奏：让 Agent 在 Canvas2D 三角钢琴上弹奏点播曲目，Salamander Grand 真实采样音色，沉浸式舞台，88 键可弹。
+- [dsh-blackjack](https://github.com/yul761/dsh-blackjack) - 对话里的 21 点牌桌：每日免费手数赢 CHIP，可单向兑换为模型额度，只在你自己配置的额度耗尽时由续命路由接管那一次失败的请求；奖池由运营者出资，服务端与可审计的账本同仓开源。
 
 ## Plugin Ecosystem & Development
 


### PR DESCRIPTION
Adds one entry to **Fun & Lifestyle**, in both `README.md` and `README.zh-CN.md`.

- Repo: https://github.com/yul761/dsh-blackjack (MIT, `dsh-plugin` topic)
- npm: [`dsh-blackjack`](https://www.npmjs.com/package/dsh-blackjack) — pins dsh `0.1.0-rc.6`

What it is: a blackjack table in the conversation. Free daily hands win an in-game currency that converts one-way into model credit, and a fallback route spends that credit only when the player's own provider quota is exhausted — so a run that would have died on a quota error keeps going. The credit is non-withdrawable, non-transferable, and can only be spent through the project's own metering proxy.

The server is in the same repo (self-hostable, four-bucket conservation ledger, metering proxy, kill switch), so anyone can run their own pool instead of the operator's.

Fun & Lifestyle seemed the right category — it's a game — but it also does something none of the other entries there do, so if you'd rather file it elsewhere, happy to move it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)