### PR TITLE
Add dsh-pianist to Fun & Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,6 +604,7 @@ Management panel: Settings → Plugins.
 - [dsh-emoji](https://github.com/dsh-external/dsh-emoji) - Emoji plugin (cordis).
 - [dsh-travel-plugin](https://github.com/dsh-external/dsh-travel-plugin) - Travel plugin.
 - [dsh-weather](https://github.com/sunshine-lang/dsh-weather) - Weather tool: current conditions and multi-day forecasts via Open-Meteo (free, no API key).
+- [dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) - Piano performance: the agent plays a requested piece on a Canvas2D grand piano with Salamander Grand samples, immersive stage visuals, and a playable 88-key keyboard.
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF toolbox: extract text, metadata, and page ranges via pdfjs-dist (local, no API key).
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - Pixel whale companion (blink/tail/spout/hearts).
 - [dsh-muyu](https://github.com/liuwenji007/dsh-muyu) - Wooden-fish overlay in the Web client's lower-right: knock the whale for per-session merit; auto-knocks while the model thinks or streams.
@@ -624,6 +625,7 @@ Management panel: Settings → Plugins.
 - [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe) - Steam-style plugin marketplace: subscribe on the web, sync with one command into a dsh profile; 500+ community plugins with verified curation and a zero-dependency CLI.
 - [dsh-vibe-pack](https://github.com/LeemanCheung/dsh-vibe-pack) - Transactional data-only configuration pack manager with integrity, ownership, preview, diff, and rollback safeguards.
 - [Luaphes/dsh-plugins-market](https://github.com/Luaphes/dsh-plugins-market) - Plugin market inside the DSH Web UI: crawls the dsh-plugin topic with noise filtering, curated marks, ranking and one-click install (dsh.bundle-verified).
+- [dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) - Piano performance: the agent plays a requested piece on a Canvas2D grand piano with Salamander Grand samples, immersive stage visuals, and a playable 88-key keyboard.
 
 ## Plugin Ecosystem & Development
 

--- a/README.md
+++ b/README.md
@@ -625,7 +625,6 @@ Management panel: Settings → Plugins.
 - [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe) - Steam-style plugin marketplace: subscribe on the web, sync with one command into a dsh profile; 500+ community plugins with verified curation and a zero-dependency CLI.
 - [dsh-vibe-pack](https://github.com/LeemanCheung/dsh-vibe-pack) - Transactional data-only configuration pack manager with integrity, ownership, preview, diff, and rollback safeguards.
 - [Luaphes/dsh-plugins-market](https://github.com/Luaphes/dsh-plugins-market) - Plugin market inside the DSH Web UI: crawls the dsh-plugin topic with noise filtering, curated marks, ranking and one-click install (dsh.bundle-verified).
-- [dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) - Piano performance: the agent plays a requested piece on a Canvas2D grand piano with Salamander Grand samples, immersive stage visuals, and a playable 88-key keyboard.
 
 ## Plugin Ecosystem & Development
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -622,6 +622,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [zoahdev/dsh-subscribe](https://github.com/zoahdev/dsh-subscribe) - Steam 式插件市场：网页一键订阅，一条命令同步到 dsh profile；500+ 社区插件，带验证精选，零依赖 CLI。
 - [dsh-vibe-pack](https://github.com/LeemanCheung/dsh-vibe-pack) - 仅数据的事务式配置包管理器，提供完整性、归属、预览、差异和回滚保护。
 - [Luaphes/dsh-plugins-market](https://github.com/Luaphes/dsh-plugins-market) - DSH Web UI 内插件市场：全量嗅探 dsh-plugin topic，过滤蹭标签噪音，保留人工精选标记，支持排序/搜索/语言过滤与一键安装（安装前校验 dsh.bundle 声明）。
+- [dsh-pianist](https://github.com/Laplace-bit/dsh-pianist) - 钢琴演奏：让 Agent 在 Canvas2D 三角钢琴上弹奏点播曲目，Salamander Grand 真实采样音色，沉浸式舞台，88 键可弹。
 
 ## Plugin Ecosystem & Development
 


### PR DESCRIPTION
Adds [dsh-pianist](https://github.com/Laplace-bit/dsh-pianist), a piano performance plugin for DeepSeek Harness: the agent plays a requested piece on a Canvas2D grand piano with real Salamander Grand samples and a playable 88-key keyboard.

- One-line factual entries appended to the Fun & Lifestyle section of both README.md and README.zh-CN.md, per the entry standard (no badges, no blurbs)
- Installs via `dsh plugin add` (`dsh.bundle` manifest); published on npm as `dsh-pianist`; demo: https://laplace-bit.github.io/dsh-pianist/