### PR TITLE
Add dsh-history-question-nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ Management panel: Settings → Plugins.
 
 ## UI, Themes & Interaction
 
+- [dsh-history-question-nav](https://github.com/TropicWiden/dsh-history-question-nav) - A right-side **Questions** panel that lists every question you ask in the current session and scrolls to the matching answer on click. Bilingual (zh/en).
 - [dsh-scenery-background](https://github.com/soslowsnail/dsh-scenery-background) - Rotating Web UI backgrounds with daily and slideshow modes, five offline SVG scenes, optional Unsplash photos, glass panels, and a floating control.
 - [dsh-zh-commands](https://github.com/Semidia/dsh-zh-commands) - Chinese slash-command enhancement: six new Chinese commands (/help /status /time /cwd /whoami /preset) plus in-place localization of every built-in command description in the slash menu.
 - [dsh-skin-studio](https://github.com/LeemanCheung/dsh-skin-studio) - Local semantic-token theme editor with palette extraction, WCAG auditing, preview, and export.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -221,6 +221,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## UI, Themes & Interaction
 
+- [dsh-history-question-nav](https://github.com/TropicWiden/dsh-history-question-nav) 在窗口右侧列出当前会话的每个历史提问标题，点击即定位到对应回答。
 - [dsh-scenery-background](https://github.com/soslowsnail/dsh-scenery-background) - 山海主题 Web UI 背景轮换插件：支持每日一图与循环轮播，内置 5 张离线 SVG 场景、可选 Unsplash 摄影图、毛玻璃面板和悬浮控制。
 - [dsh-zh-commands](https://github.com/Semidia/dsh-zh-commands) - 中文斜杠命令增强：新增 /help /status /time /cwd /whoami /preset，并本地化斜杠菜单中的内置命令说明。
 - [dsh-skin-studio](https://github.com/LeemanCheung/dsh-skin-studio) - 本地语义令牌主题编辑器，支持色板提取、WCAG 审计、预览和导出。


### PR DESCRIPTION
Add [dsh-history-question-nav](https://github.com/TropicWiden/dsh-history-question-nav) to the list.

A DeepSeek Harness **web plugin**: a right-side "Questions" panel that lists every user question in the current session and scrolls to the matching answer on click. Bilingual (zh/en), follows the active session.