### PR TITLE
docs: add dsh-forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,6 +512,7 @@ Management panel: Settings → Plugins.
 - [duyanta123/dsh-preset-scaffold](https://github.com/duyanta123/dsh-preset-scaffold) - Project-init scaffold preset: strict five-phase runbook, engineering standards, and six runnable starter templates (node-ts / react-vite / python / go / spring-boot / monorepo).
 - [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Independent browser acceptance testing for agent deliverables: JSON spec in, real Chromium (Firefox/WebKit) verdict out (PASS/FAIL with screenshot receipts). MCP server + CLI + GitHub Action, works with any agent and CI (MIT).
 - [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) - Transactional uninstall engine: validate/preview/execute/undo per action with Saga rollback, WAL crash recovery, hash-chain audit, hardlink dedup, and a Bayesian oracle that predicts success probability before you commit (MIT).
+- [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) - Read-only Gitea and Forgejo tools: instance version, repositories, issue and pull request search and read, PR diffs, and Actions runs, jobs and logs.
 
 ## Security & Governance
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -508,6 +508,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [duyanta123/dsh-preset-scaffold](https://github.com/duyanta123/dsh-preset-scaffold) - 项目初始化脚手架预设：严格五阶段流程 + 工程规范 + 六套可运行模板（node-ts / react-vite / python / go / spring-boot / monorepo）。
 - [dsh-verify](https://github.com/263311487-ux/dsh-verify) - Agent 交付物的独立浏览器验收测试：JSON 规格进，真实浏览器（Chromium/Firefox/WebKit）执行出结论（PASS/FAIL + 截图证据）。MCP 服务器 + CLI + GitHub Action，兼容任意 Agent 与 CI（MIT）。
 - [beijingwahw/dsh-nuke-plugin](https://github.com/beijingwahw/dsh-nuke-plugin) - 事务式卸载引擎：每个动作支持校验/预览/执行/撤销，Saga 回滚、WAL 崩溃恢复、哈希链审计、硬链接去重，并提供贝叶斯先知在执行前预测成功率（MIT）。
+- [maxmilian/dsh-forge](https://github.com/maxmilian/dsh-forge) - 自建 Gitea / Forgejo 的只读工具：实例版本、仓库列表、议题与 PR 搜索和读取、PR diff，以及 Actions 运行、任务与日志。
 
 ## Security & Governance
 


### PR DESCRIPTION
Adds [dsh-forge](https://github.com/maxmilian/dsh-forge), a read-only DeepSeek Harness plugin for self-hosted Gitea and Forgejo instances.

- Instance version, repository listing, issue / pull request search and read
- PR diffs and changed-file metadata
- Actions runs, jobs and plaintext job logs
- MIT licensed, release `v0.3.1` with a prebuilt tarball (no install-time TypeScript build)
- Tested against `@deepseek-ai/dsh-tools 0.1.1-rc.2`; CI plus live-instance integration tests
- Topics: `dsh-plugin`, `deepseek-harness`, `gitea`, `forgejo`

All language files are updated in the same PR; the diff is insertions only.