### PR TITLE
docs: add dsh-tmux-cc

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Management panel: Settings → Plugins.
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS meter.
 - [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) - Sidebar: file rendering/terminal/Git/subagents/custom APIs.
 - [dsh-web-panel](https://github.com/dsh-external/dsh-web-panel) - Embedded terminal dock + Git Review + file view.
+- [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) - Persistent tmux control-mode cockpit for DSH Web that mirrors native panes in a dock.
 - [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) - Subagent tree visualization.
 - [dsh-web-workflow-visualizer](https://github.com/dsh-external/dsh-web-workflow-visualizer) - Workflow visualization.
 - [dsh-ui-progress](https://github.com/dsh-external/dsh-ui-progress) - Progress indicators.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -316,6 +316,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-tps](https://github.com/dsh-external/dsh-tps) - TPS 仪表
 - [DSH-better-sidebar](https://github.com/dsh-external/DSH-better-sidebar) - 侧边栏：文件渲染/终端/Git/子代理/自定义 API
 - [dsh-web-panel](https://github.com/dsh-external/dsh-web-panel) - 内嵌终端 dock + Git Review + 文件视图
+- [dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) - 为 DSH Web 提供持久的 tmux 控制模式驾驶舱，在停靠栏中镜像原生窗格。
 - [dsh-subagent-tree](https://github.com/dsh-external/dsh-subagent-tree) - 子代理树可视化
 - [dsh-web-workflow-visualizer](https://github.com/dsh-external/dsh-web-workflow-visualizer) - workflow 可视化
 - [dsh-ui-progress](https://github.com/dsh-external/dsh-ui-progress) - 进度


### PR DESCRIPTION
Add [adrianleb/dsh-tmux-cc](https://github.com/adrianleb/dsh-tmux-cc) to **UI, Themes & Interaction**.

Persistent tmux control-mode cockpit for DSH Web that mirrors native panes in a dock. Bilingual README entries, no marketing copy.

Install: `dsh plugin --profile web add github:adrianleb/dsh-tmux-cc`