### PR TITLE
docs: add dsh-qingagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,7 @@ Management panel: Settings → Plugins.
 ## Office & Documents
 
 - [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - Create, edit, inspect, and deliver spreadsheets, documents, presentations, databases, and canvases in DeepSeek Harness, with live preview and worktree review.
+- [dsh-qingagent](https://github.com/void2anything/dsh-qingagent) - Writing bridge to the open-source QingAgent client: the agent drafts and revises documents on a typeset rice-paper panel (mermaid, drawio, tables, KaTeX), every edit staged for review before it lands; requires the QingAgent desktop client running locally.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -566,6 +566,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Office & Documents
 
 - [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - 在 DeepSeek Harness 中创建、编辑、检查和交付表格、文档、演示文稿、多维表格和画布，支持实时预览与 worktree 审阅。
+- [dsh-qingagent](https://github.com/void2anything/dsh-qingagent) - 把开源 AI 写作客户端「青简 QingAgent」接进 DeepSeek Harness：对话里起草改稿，右侧宣纸面板排版渲染（mermaid、drawio、表格、KaTeX），每处修改先摆在纸上供审阅、提交才落稿；需本机运行青简桌面客户端。
 
 ## Notifications & Channels
 

--- a/scripts/generate-catalog.py
+++ b/scripts/generate-catalog.py
@@ -487,6 +487,7 @@ EXTRA_TOPIC_REPOS = [
     {"full_name": "ShadowQuill/DialogueContextBridge", "name": "DialogueContextBridge", "html_url": "https://github.com/ShadowQuill/DialogueContextBridge", "description": "Cross-session dialogue consensus snapshots with SQLite FTS5 and AES-256-GCM encryption"},
     {"full_name": "hellofuture2068/dsh-simple-view", "name": "dsh-simple-view", "html_url": "https://github.com/hellofuture2068/dsh-simple-view", "description": "Decluttered chat view with compact layout, bubbles, and concise-reply prompt control"},
     {"full_name": "FriendsHL/dsh-agent-factory", "name": "dsh-agent-factory", "html_url": "https://github.com/FriendsHL/dsh-agent-factory", "description": "Preset-aware agent composition with baseline and candidate experiments"},
+    {"full_name": "void2anything/dsh-qingagent", "name": "dsh-qingagent", "html_url": "https://github.com/void2anything/dsh-qingagent", "description": "Writing bridge to the open-source QingAgent client: drafts and revisions render on a typeset rice-paper panel, every edit staged for review before it lands"},
 ]
 
 


### PR DESCRIPTION
Adds dsh-qingagent to **Office & Documents** in both `README.md` and `README.zh-CN.md`, and to `EXTRA_TOPIC_REPOS` in `scripts/generate-catalog.py` — the repo carries the `dsh-plugin` topic but sits beyond the Search API's 1000-result window, so the topic scan never reaches it.

- Repo: https://github.com/void2anything/dsh-qingagent (Apache-2.0; npm `dsh-qingagent` 0.1.46)
- What it does: bridges the open-source QingAgent writing client into DSH — the agent drafts and revises documents in conversation, a typeset rice-paper panel renders them (mermaid, drawio, tables, KaTeX), and every edit is staged for review before it lands. Requires the QingAgent desktop client running locally.
- Install: `npx @deepseek-ai/dsh plugin --profile web add dsh-qingagent@latest`

Checks done: same one-line entry in both language READMEs (translated description, same category and position); `generate-catalog.py` still parses (python3 ast check). Did not run awesome-lint — the workflow is manual-dispatch only.

中文：把「青简 QingAgent」写作插件加入两份 README 的 Office & Documents 分类，并加入 `generate-catalog.py` 的 `EXTRA_TOPIC_REPOS`（仓库带 `dsh-plugin` topic，但在 Search API 1000 条窗口之外，topic 扫描抓不到）。

Generated with [Claude Code](https://claude.com/claude-code)