### PR TITLE
docs: add dsh-plugin-governor-extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,7 @@ Management panel: Settings → Plugins.
 
 ## Runtime & Operations
 
+- [Ghost011118/dsh-plugin-governor-extension](https://github.com/Ghost011118/dsh-plugin-governor-extension) - Patch-based DSH plugin governance extension: plugin inventory and whitelist controls, policy trials, runtime tool-call admission rules, plus supervised restart and automatic rollback through dsh-autostart.
 - [fakechris/dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) - Self-healing DSH ops toolbox: official daily-snapshot A/B slot rotation (auto plugin migration + acceptance-gated atomic switch + one-click rollback), a 10s watchdog that auto-relaunches the web and resumes interrupted turns, and an out-of-band dsh-doctor (diagnosis → mechanical repair → LLM deep repair → relaunch) when web and agent are both down.
 - [zoahdev/dsh-disk-audit](https://github.com/zoahdev/dsh-disk-audit) - Disk-usage audit for dsh data directories: total size, per-directory breakdown, largest files, oversized-file warnings (session logs can hit hundreds of MB) and cleanup suggestions (CLI + `disk_audit` tool).
 - [zoahdev/dsh-cn-boot](https://github.com/zoahdev/dsh-cn-boot) - China-network bootstrap: probes npm/npmmirror/GitHub/HuggingFace/Gitee and local proxies, recommends mirrors/proxy, generates a PowerShell + bash bootstrap (CLI + `cn_boot` tool).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -681,6 +681,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Runtime & Operations
 
+- [Ghost011118/dsh-plugin-governor-extension](https://github.com/Ghost011118/dsh-plugin-governor-extension) - 基于补丁的 DSH 插件治理扩展：提供插件清单与白名单控制、策略试运行、运行时工具调用准入规则，并通过 dsh-autostart 实现受控重启和自动回滚。
 - [fakechris/dsh-harness-ops](https://github.com/fakechris/dsh-harness-ops) - DSH 自愈运维工具箱：官方每日快照 A/B 双槽轮换（旧插件自动迁移 + 验收门禁原子切换 + 一键回滚）、10s 守护自动拉起 web 并续接被打断的回合，以及 web/agent 全挂时的 out-of-band dsh-doctor（诊断 → 机械修复 → LLM 深度修复 → 拉起）。
 - [zoahdev/dsh-disk-audit](https://github.com/zoahdev/dsh-disk-audit) - dsh 数据目录磁盘占用审计：总大小、按目录拆分、最大文件、超大文件告警（会话日志可达数百 MB）与清理建议（CLI + `disk_audit` 工具）。
 - [zoahdev/dsh-cn-boot](https://github.com/zoahdev/dsh-cn-boot) - 国内网络引导：探测 npm/npmmirror/GitHub/HuggingFace/Gitee 与本地代理，推荐镜像/代理并生成 PowerShell + bash 引导脚本（CLI + `cn_boot` 工具）。


### PR DESCRIPTION
Adds a factual bilingual entry under Runtime & Operations for the public, patch-based DSH Plugin Governor Extension.\n\nIt covers plugin inventory and whitelist controls, policy trials, runtime tool-call admission rules, and the separately configured dsh-autostart restart/health-check/rollback path.