### PR TITLE
Add dsh-workspace-sort to UI, Themes & Interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Management panel: Settings → Plugins.
 - [dsh-mcp-panel](https://github.com/PerryLink/dsh-mcp-panel) - MCP management console for the official DSH MCP client: server CRUD with approval-gated, backed-up profile writes, a tool trial console through the official tool pipeline, health diagnostics, and connection status.
 - [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) - Pin sessions and workspaces to the top of the sidebar with per-pin colors, plus a navigation organizer: boards, tags and saved views, health summaries, and /goto.
 - [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) - One-command skinning for DSH Web: 8 original themes, wallpaper (opacity/blur/gradient/URL), per-user accent, and shareable theme packs + favorites + surprise-me. Purely native token system.
+- [dsh-workspace-sort](https://github.com/Moonshile/moonshile-dsh-plugins) - Re-sorts sidebar workspaces by last activity once per day; stable order within the day.
 
 ## Dashboards & Session UX
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -275,6 +275,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-premium-themes](https://github.com/xiaoyanzi191/dsh-premium-themes) - 8 套精选配色方案与自定义调色板导入（名称+方案+种子色推导完整 token 映射），设置页「调色板」行，热插拔安装。
 - [dsh-session-pin](https://github.com/PerryLink/dsh-session-pin) - 把会话与工作区置顶到侧边栏顶部（每 pin 换色），另加导航组织器：boards、标签与保存视图、健康摘要与 /goto。
 - [RevolutionLA/dsh-dream-skin](https://github.com/RevolutionLA/dsh-dream-skin) - DSH Web 一键换肤插件：8 套原创主题、背景壁纸（透明度/模糊/渐变/URL）、每用户强调色、主题包导入导出/分享链接、收藏与随机，纯原生 token 系统。
+- [dsh-workspace-sort](https://github.com/Moonshile/moonshile-dsh-plugins) - 侧边栏工作区每日按最近活动排序一次，当天顺序稳定。
 
 ## Dashboards & Session UX
 


### PR DESCRIPTION
## Summary

## Summary

Add [dsh-workspace-sort](https://github.com/Moonshile/moonshile-dsh-plugins) to the curated list (EN + ZH).

- Re-sorts sidebar workspaces by last activity **once per day**; stable within the day.
- Installs as an auto-activating `dsh.bundle`: `dsh plugin --profile web add dsh-workspace-sort`.
- MIT, zero runtime dependencies, bilingual docs.
