### PR TITLE
docs: add dsh-grafana-query, dsh-sentry and dsh-odoo

### DIFF
--- a/README.md
+++ b/README.md
@@ -722,6 +722,8 @@ Management panel: Settings → Plugins.
 - [dsh-fast](https://github.com/PerryLink/dsh-fast) - Read-only performance diagnostics: session load timing, spill hits, compaction stats, context-injection volume, and cache-hit rate via the /fast command and fast_report tool, sampled asynchronously off the model path.
 - [ClawMetry](https://github.com/vivekchand/clawmetry) - Local zero-config dashboard that reads dsh session logs and shows transcripts, token usage, cost, and tool calls.
 - [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) - Diagnose and safely repair corrupted DSH session history: raw zstd/JSONL artifact validation (header, seq, tool-call IDs, turn/step closure), deterministic repair of empty tool-call ID chains, single-slot pre-repair backup + restore, and an audit trail.
+- [maxmilian/dsh-grafana-query](https://github.com/maxmilian/dsh-grafana-query) - Read-only Grafana tools over the data source proxy: instance health, data sources, instant and range PromQL queries, current alert state, and provisioned alert rules.
+- [maxmilian/dsh-sentry](https://github.com/maxmilian/dsh-sentry) - Read-only Sentry tools: project listing, issue search and detail, and the latest or a specific event with a trimmed stacktrace that drops local variables, request data, and secret-looking tags.
 ## Domain & Specialist Skills
 
 - [dsh-fund-research](https://github.com/PerryLink/dsh-fund-research) - Deterministic research reports for Chinese public mutual funds: public-source data collection (Tiantian Fund/Eastmoney), pure-function metrics (performance decomposition, holdings penetration, style attribution, manager profile), and versioned reports with a per-number snapshot traceability appendix.
@@ -762,6 +764,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-industry-research](https://github.com/PerryLink/dsh-industry-research) - Industry and company research domain pack: industry_map chain maps, public-source policy/news tracking over ctx.web (industry_track), company_scan cards from user data files, and industry_report with an optional ctx.researchReport sealing bridge and a builtin-fallback renderer, plus two methodology skills.
 - [dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) - Deterministic data profiling, cleaning, and verification: data_profile / data_clean / data_verify tools plus a frozen cross-plugin verifyCitations citation-checking contract, with durable reports in a storage domain.
+- [maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo) - Read-only Odoo tools over JSON-RPC: server info, model field introspection, and a restricted search_read on an allow list of models. A draft-create tool is registered only when allowWrite is enabled.
 ## Tools & Utilities
 
 - [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) - Read-only DSH Web plugin for inspecting and searching Milvus or Zilliz Cloud collections from chat, including scalar, BM25, dense, and hybrid queries.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -720,6 +720,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [ClawMetry](https://github.com/vivekchand/clawmetry) - 本地零配置仪表盘：读取 dsh 会话日志，展示会话记录、token 用量、成本与工具调用。
 - [Zn-Dk/dsh-session-repair](https://github.com/Zn-Dk/dsh-session-repair) - 诊断并安全修复损坏的 DSH 会话历史：raw zstd/JSONL 工件校验（header、seq、tool-call ID、turn/step 闭合）、空 tool-call ID 链的确定性修复、单槽 pre-repair 备份与恢复、审计记录。
 - [JohnXu22786/hooks-adapter](https://github.com/JohnXu22786/hooks-adapter) - 通用 hooks 兼容层：在 dsh 上运行 Claude Code / Codex / opencode 配置中声明的 hooks。
+- [maxmilian/dsh-grafana-query](https://github.com/maxmilian/dsh-grafana-query) - 面向 Grafana 的只读工具，经数据源代理：实例健康、数据源列表、instant 与 range PromQL 查询、当前告警状态与已配置的告警规则。
+- [maxmilian/dsh-sentry](https://github.com/maxmilian/dsh-sentry) - 面向 Sentry 的只读工具：项目列表、议题搜索与详情，以及最新或指定 event 的裁剪堆栈——局部变量、请求数据与疑似机密的 tag 会被移除。
 ## Domain & Specialist Skills
 
 - [dsh-fund-research](https://github.com/PerryLink/dsh-fund-research) - 中国公募基金确定性研究报告：公开源数据采集（天天基金/东方财富）、纯函数指标计算（业绩拆解/持仓穿透/风格归因/经理画像），版本化报告附逐数字可回溯源快照的附录。
@@ -760,6 +762,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-industry-research](https://github.com/PerryLink/dsh-industry-research) - 行业/公司研究领域包：industry_map 产业链建图、industry_track 经 ctx.web 的公开源政策动态跟踪、company_scan 基于用户数据文件的公司速览卡、industry_report 研究报告（可选 ctx.researchReport 引擎封存桥，缺席时内置降级渲染），附两个研究方法论技能。
 - [dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) - 确定性的数据画像、清洗与校验：data_profile / data_clean / data_verify 工具，外加冻结的跨插件 verifyCitations 引用核验契约，报告持久化到存储域。
+- [maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo) - 经 JSON-RPC 的 Odoo 只读工具：服务器信息、模型字段自省，以及白名单模型上的受限 search_read。草稿创建工具需显式开启 allowWrite 才会注册。
 ## Tools & Utilities
 
 - [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) - 只读 DSH Web 插件，可在对话中检查和搜索 Milvus 或 Zilliz Cloud Collection，支持标量、BM25、稠密向量与混合查询。


### PR DESCRIPTION
Adds three read-only DSH plugins to the curated list. Both language versions updated in the same PR, same entries, translated descriptions.

## Entries

**Runtime & Operations** — both are production observability integrations, sitting next to the other observability entries in this section (`dsh-observe`, `dsh-trace`, `loongsuite/dsh-plugin`).

- `maxmilian/dsh-grafana-query` — npm `dsh-grafana-query` v0.1.0. Read-only Grafana tools over the data source proxy: instance health, data sources, instant and range PromQL queries, current alert state, provisioned alert rules.
- `maxmilian/dsh-sentry` — npm `dsh-sentry` v0.1.0. Read-only Sentry tools: project listing, issue search and detail, latest or specific event with a trimmed stacktrace (local variables, request data, and secret-looking tags are dropped).

**Domain & Specialist Skills**

- `maxmilian/dsh-odoo` — npm `dsh-odoo` v0.1.0. Read-only Odoo tools over JSON-RPC: server info, model field introspection, restricted `search_read` on an allow list of models. A draft-create tool is registered only when `allowWrite` is enabled. Filed here as business/ERP data access, alongside `dsh-data-agent` and the other data-domain entries.

Same author as the existing `maxmilian/dsh-forge` and `maxmilian/dsh-sonarqube` entries.

## Entry standard

- All three are real public repositories, MIT, zero runtime dependencies, carrying the `dsh-plugin` topic, with `dsh.bundle.patch` in `package.json` pointing at a committed `cordis.patch.yml`, and published to npm.
- Descriptions are one line each, factual, no badges or screenshots, and scoped to what the code actually registers.

## Checks run locally

- `npx awesome-lint README.md` — 15 warnings, all pre-existing on `main` (git/docker/Postgres capitalisation on other entries); none on the added lines.
- `git diff --name-only upstream/main..HEAD` → only `README.md` and `README.zh-CN.md`. `CATALOG.md` and everything under `scripts/` and `.github/` are untouched.
- Branch cut from `upstream/main`, so the diff is exactly six added lines.
- Verified all three repository links return 200 and that none of the three is already listed in either README.