### PR TITLE
docs: add dsh-vibegap

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,7 @@ Management panel: Settings → Plugins.
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF toolbox: extract text, metadata, and page ranges via pdfjs-dist (local, no API key).
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - Pixel whale companion (blink/tail/spout/hearts).
 - [dsh-muyu](https://github.com/liuwenji007/dsh-muyu) - Wooden-fish overlay in the Web client's lower-right: knock the whale for per-session merit; auto-knocks while the model thinks or streams.
+- [dsh-vibegap](https://github.com/ktao732084-arch/dsh-vibegap) - Vocabulary flashcards for agent wait time: a spelling card appears in the Web client lower-right after ~18s of agent activity and retreats when the session finishes or needs input; optional shared progress with the local VibeGap desktop app.
 - [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - Desktop whale pet with live session state.
 - [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) - macOS desk pet in a real always-on-top window rather than a page widget: six states from local DSH, native right-click menu, and a bundled skill that turns one photo into a full eighteen-pose skin.
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - Desktop pet, Rust edition.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -615,6 +615,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-pdf](https://github.com/sunshine-lang/dsh-pdf) - PDF 工具箱：基于 pdfjs-dist 提取文本、元数据与页码范围（本地解析，无需 API key）。
 - [dsh-ui-whale](https://github.com/dsh-external/dsh-ui-whale) - 像素鲸鱼伙伴（眨眼/摆尾/喷水/爱心）
 - [dsh-muyu](https://github.com/liuwenji007/dsh-muyu) - Web 右下角电子木鱼：点头记本会话功德；模型思考或流式输出时会自动敲。
+- [dsh-vibegap](https://github.com/ktao732084-arch/dsh-vibegap) - Agent 等待间隙背单词:agent 持续运行约 18 秒后 Web 右下角浮现拼写单词卡,会话完成或等待输入时自动收起;可与本机 VibeGap 桌面端共享词书与进度。
 - [dsh-pet](https://github.com/FlytoMAYDAY80/dsh-pet) - 桌面小鲸鱼，实时感知会话状态
 - [dsh-desk-pet](https://github.com/anneheartrecord/dsh-desk-pet) - 用真的置顶窗口而不是页面挂件实现的 macOS 桌宠：六种状态跟着本地 DSH 走，原生右键菜单，自带的 skill 把一张照片变成整套十八个姿势的皮肤。
 - [dsh-pet-rs](https://github.com/dsh-external/dsh-pet-rs) - 桌宠 Rust 版


### PR DESCRIPTION
Adds dsh-vibegap under Fun & Lifestyle (both README.md and README.zh-CN.md, same PR).

Vocabulary flashcards for agent wait time: a spelling card appears in the Web client lower-right after ~18s of agent activity and retreats when the session finishes or needs input. Standalone (wordbook downloaded on demand, progress in the official snapshot store); optionally shares progress with the local VibeGap desktop app.

Repo: https://github.com/ktao732084-arch/dsh-vibegap (npm: dsh-vibegap)