### PR TITLE
docs: add openllmsh/dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,6 +475,7 @@ Management panel: Settings → Plugins.
 - [JohnXu22786/adversarial-review](https://github.com/JohnXu22786/adversarial-review) - Gavel-review: adversarial multi-perspective code review — parallel attack lenses, deterministic static sentinels, cross-lens merge/dedup, severity grading, suppression rules and review history; dsh tools + standalone CLI.
 - [dsh-plugin-cloud](https://github.com/AgentsDanceAI/deepseek-harness-cloud/tree/main/packages/dsh-plugin-cloud) - DSH Cloud gateway provider: device-authorized login writes a multi-model provider row (DeepSeek, GPT, Claude, Gemini and more) into the user config layer; works against the hosted service or a self-hosted deployment.
 - [dsh-plugin-rollout-scout](https://github.com/SpookySandwich/dsh-plugin-rollout-scout) - Detects which conversation model your account is being served: launches concurrent throwaway probe conversations, scores each streaming chain-of-thought by how its paragraphs open, and cancels probes that read as the older model within seconds.
+- [openllmsh/dsh](https://github.com/openllmsh/dsh) - Routes the harness through the OpenLLM gateway: a pure-config Cordis patch that adds an `openllm` provider to the in-box pi-ai adapter pointed at the local daemon (`127.0.0.1:8787/v1`, no API key held by dsh) and registers the `openllm mcp` stdio server (openllm, claude-context, supermemory tool groups).
 
 ## Git & Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -467,6 +467,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [rapid-mlx-dsh-provider](https://github.com/raullenchai/rapid-mlx-dsh-provider) - Rapid-MLX（Apple 芯片本地推理服务）原生 provider：注册 `rapid-mlx` 的 LlmAdapter 路由，从服务端 `/v1/models` 读取模型信息（上下文窗口、推理解析器、能力）而非手写 settings.yaml，切换所服务的模型无需重新配置，且上下文压缩按真实上下文窗口计时。
 - [JohnXu22786/model-catalog](https://github.com/JohnXu22786/model-catalog) - 模型目录自动发现：从 OpenAI 兼容的 API 主机获取模型列表、价格与能力，归一化为可直接使用的配置。
 - [dsh-browser-vision](https://github.com/tristan-mcinnis/dsh-browser-vision) - 视觉浏览器工具：以 browser-use 通过 CDP 驱动真实 Chrome，并用 deepseek-v4-flash-vision-exp 读取页面，可识别 canvas 上绘制的文字、图片中烧录的文字与图表中的数值；支持按调用方提供的 JSON Schema 返回结构化结果，并统计每次运行的 token 成本
+- [openllmsh/dsh](https://github.com/openllmsh/dsh) - 将 DeepSeek Harness 接入 OpenLLM 网关：纯配置的 Cordis patch，为内置 pi-ai 适配器添加指向本地守护进程（`127.0.0.1:8787/v1`，dsh 侧不持有 API Key）的 `openllm` provider，并注册 `openllm mcp` stdio 服务（openllm、claude-context、supermemory 工具组）。
 
 ## Git & Engineering
 


### PR DESCRIPTION
Adds `openllmsh/dsh` to **Models & Inference**.

A DeepSeek Harness bundle that routes the harness through the OpenLLM gateway — a pure-config Cordis patch (`cordis.patch.yml`, no runtime code) that adds an `openllm` provider to the in-box `llm-pi-ai` adapter pointed at the local daemon, and registers the `openllm mcp` stdio server.

- Public repo, live link, `dsh-plugin` topic set
- Installable as-is: `dsh plugin --profile web add github:openllmsh/dsh`
- Both `README.md` and `README.zh-CN.md` updated with matching entries
- Markdown only, no other changes