### PR TITLE
docs: add Cooberped/dsh-evidence (Office & Documents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ Management panel: Settings → Plugins.
 ## Office & Documents
 
 - [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - Give DeepSeek Harness a real office environment. Univer Office Plugin brings spreadsheets, docs, slides, canvases, relational tables, and more into one runtime — with connected data, validation, versioned changes, and isolated worktrees for multi-agent collaboration.
+- [Cooberped/dsh-evidence](https://github.com/Cooberped/dsh-evidence) - Turns attached files into versioned evidence: `search_documents` builds a private local index (SQLite FTS5 after a startup capability probe, dependency-free JS fallback otherwise) and returns compact evidence blocks carrying an exact coordinate — PDF page, PPTX slide, text/DOCX line range, or quoted XLSX `Sheet!Range` — which `read_document` expands only while the content version still matches. Contiguous CJK runs are indexed as overlapping bigrams and queried as phrases, so word order is preserved; uploaded raster images take the native vision attachment path instead.
 
 ## Notifications & Channels
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -570,6 +570,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Office & Documents
 
 - [dream-num/dsh-univer-office](https://github.com/dream-num/dsh-univer-office) - 为 DeepSeek Harness 打造一个真正的办公环境。Univer Office 插件将电子表格、文档、幻灯片、画布、多维表格等汇聚到同一个运行时——数据互联、修改经过校验、变更按版本管理，并以隔离工作树支持多 Agent 协作。
+- [Cooberped/dsh-evidence](https://github.com/Cooberped/dsh-evidence) - 把附件变成带版本的证据：`search_documents` 在本机建立私有索引（启动探测能力，可用则 SQLite FTS5，否则回退零依赖 JS 后端），返回带精确坐标的紧凑证据块——PDF 页码、PPTX 幻灯片、text/DOCX 行区间或带引号的 XLSX `Sheet!Range`——`read_document` 仅在内容版本仍匹配时展开该坐标。中文连续段按重叠 bigram 建索引并以短语查询，保持语序；上传的栅格图片走原生视觉附件链路。
 
 ## Notifications & Channels
 


### PR DESCRIPTION
Adds one entry to **Office & Documents**, in both `README.md` and `README.zh-CN.md` as the guidelines ask. Diff is +2/−0; no existing entry is touched.

**[Cooberped/dsh-evidence](https://github.com/Cooberped/dsh-evidence)** — a DeepSeek Harness plugin that turns attached files into versioned evidence instead of prompt bulk.

Every claim in the entry is checkable in the repo:

- `search_documents` / `read_document` are registered in [`src/index.ts`](https://github.com/Cooberped/dsh-evidence/blob/main/src/index.ts).
- The startup capability probe and the JS fallback are in [`src/retrieval/runtime.ts`](https://github.com/Cooberped/dsh-evidence/blob/main/src/retrieval/runtime.ts); `pnpm benchmark:retrieval` runs the same 11 correctness cases against both backends.
- Coordinates (`page:N`, `slide:N`, line ranges, quoted `Sheet!Range`) and the content-version check are in [`src/tool.ts`](https://github.com/Cooberped/dsh-evidence/blob/main/src/tool.ts).
- Order-preserving CJK retrieval is the overlapping-bigram phrase plan in [`src/retrieval/tokenize.ts`](https://github.com/Cooberped/dsh-evidence/blob/main/src/retrieval/tokenize.ts); the `ordered-cjk-phrase` benchmark case asserts that `流程绩效` does not match a block containing only `绩效流程`.

Installability: `package.json` declares `dsh.bundle.patch` with a `cordis.patch.yml` next to it, and the repo has the `dsh-plugin` topic. Not on npm yet — install is from source (`dsh plugin --profile web add .`), which the README documents.

Lineage, stated plainly: this began as a fork of the MIT-licensed [`taxueseek/dsh-files`](https://github.com/taxueseek/dsh-files) and keeps its history and copyright. It has since diverged — the whole retrieval layer, versioned coordinates, PPTX support and the security hardening are new work. It is no longer a fork on GitHub and is maintained independently. I don't see `dsh-files` on this list, so this shouldn't duplicate an existing entry; happy to adjust the wording or the category if you'd rather file it elsewhere.