### PR TITLE
Add dsh-whale-musume (Fun & Lifestyle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ Management panel: Settings → Plugins.
 ## Fun & Lifestyle
 
 - [dsh-whale-companion](https://github.com/LeemanCheung/dsh-whale-companion) - Draggable whale companion with local progression, achievements, skins, and privacy-safe activity tracking.
+- [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) - Whale-girl desktop pet for the DSH Web UI: pat-to-raise growth, work-state poses, 494 dialogue lines and 30 achievements with a built-in settings panel; local-first, zero telemetry.
 - [dsh-clippy](https://github.com/sjh9714/clippy-harness) - Clippy revived as an office assistant pet that reacts to real agent state, with a classic "illegal operation" dialog on failed turns.
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern migration and next-generation agent roleplay for DSH.
 - [dsh-emoji](https://github.com/dsh-external/dsh-emoji) - Emoji plugin (cordis).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -610,6 +610,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## Fun & Lifestyle
 
 - [dsh-whale-companion](https://github.com/LeemanCheung/dsh-whale-companion) - 可拖拽的鲸鱼伙伴，提供本地成长、成就、皮肤和隐私安全的活动统计。
+- [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) - 元气鲸鱼娘桌宠：摸头养成、工作状态联动、494 条台词与 30 项成就，自带设置面板，全本地、零遥测。
 - [dsh-clippy](https://github.com/sjh9714/clippy-harness) - Clippy 复活为办公室助理宠物：对真实 agent 状态做出反应，失败回合弹出经典「非法操作」对话框。
 - [dsh-agent-rp](https://github.com/dsh-external/dsh-agent-rp) - SillyTavern 迁移与下一代 DSH Agent RP。
 - [dsh-emoji](https://github.com/dsh-external/dsh-emoji) - emoji 插件（cordis）。


### PR DESCRIPTION
Add [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) to **Fun & Lifestyle** (README.md + README.zh-CN.md).

Whale-girl desktop pet for the DSH Web UI: pat-to-raise growth, work-state poses, 494 dialogue lines, 30 achievements, built-in settings panel. Local-first, zero telemetry, MIT, 102 unit tests.

- Install: `dsh plugin --profile web add github:Sutera-Diffusus/dsh-whale-musume`
- Tagged with the `dsh-plugin` topic.