### PR TITLE
docs: refresh DeepSeek Harness Handbook coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -798,7 +798,7 @@ Management panel: Settings → Plugins.
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue aggregation hub.
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual.
-- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 162 English-canonical, source-backed guides with 186 localized documents for running, extending, and troubleshooting DSH, plus a local-browser [Install Doctor](https://sandbaseai.github.io/deepseek-harness-handbook/install-doctor.html) and [Failure Router](https://sandbaseai.github.io/deepseek-harness-handbook/diagnose.html).
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 162 English-canonical, source-backed guides with 189 localized documents for running, extending, and troubleshooting DSH, plus a searchable [Awesome resource map](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html), local-browser [Install Doctor](https://sandbaseai.github.io/deepseek-harness-handbook/install-doctor.html), and [Failure Router](https://sandbaseai.github.io/deepseek-harness-handbook/diagnose.html).
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI-compatible endpoint with free DeepSeek V4 Pro/Flash daily quotas; point DEEPSEEK_BASE_URL at it, no payment info required.
 - [DeepSeek](https://deepseek.com) - Official site.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -795,7 +795,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue 聚合仓库
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - 社区整活插件导航（皮肤/桌宠/小游戏），中英双语
-- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 从 Agent 视角讲解 DSH 运行、扩展与排障的来源可追溯手册，提供 162 篇英文 canonical 指南、186 份多语言文档，以及 Install Doctor 和 Failure Router 速查工具
+- [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 从 Agent 视角讲解 DSH 运行、扩展与排障的来源可追溯手册，提供 162 篇英文 canonical 指南、189 份多语言文档、可搜索的 [Awesome 资源地图](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html)，以及 Install Doctor 和 Failure Router 速查工具
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI 兼容接入点，提供免费的 DeepSeek V4 Pro/Flash 每日配额；把 DEEPSEEK_BASE_URL 指向它即可，无需支付信息。
 - [DeepSeek](https://deepseek.com) - 官方入口
 


### PR DESCRIPTION
Refresh the merged handbook entry from 162/186 to the current verified 162/189 coverage and link the searchable multilingual Awesome resource map. This is a factual directory snapshot update; the handbook URL and existing Install Doctor/Failure Router links remain unchanged.