### PR TITLE
Add dsh-tray: Windows system-tray guardian for DeepSeek Harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -771,6 +771,7 @@ Management panel: Settings → Plugins.
 - [dsh-data-quality](https://github.com/PerryLink/dsh-data-quality) - Deterministic data profiling, cleaning, and verification: data_profile / data_clean / data_verify tools plus a frozen cross-plugin verifyCitations citation-checking contract, with durable reports in a storage domain.
 - [maxmilian/dsh-odoo](https://github.com/maxmilian/dsh-odoo) - Read-only Odoo tools over JSON-RPC: server info, model field introspection, and a restricted search_read on an allow list of models. A draft-create tool is registered only when allowWrite is enabled.
 ## Tools & Utilities
+- [dsh-tray](https://github.com/liulifu/dsh-tray) - Windows system-tray guardian for DeepSeek Harness: launch/stop/restart the dsh service, multi-profile port bindings, snapshot-based quick recovery, plugin enable/disable, SQLite version ledger, and a client sentinel that detects a plugin failing to load, disables it and restores DSH.
 
 - [zilliztech/dsh-milvus](https://github.com/zilliztech/dsh-milvus) - Read-only DSH Web plugin for inspecting and searching Milvus or Zilliz Cloud collections from chat, including scalar, BM25, dense, and hybrid queries.
 


### PR DESCRIPTION
## What

Add [dsh-tray](https://github.com/liulifu/dsh-tray) to **Tools & Utilities** — a Windows system-tray guardian for DeepSeek Harness.

## Why it fits
- **Tool / infrastructure** (not a plugin): a standalone Windows tray program that manages the DSH service outside the plugin tree — launch/stop/restart, multi-profile port bindings, snapshot-based quick recovery, plugin enable/disable, SQLite version ledger.
- **Client sentinel (L4)**: detects when a client plugin fails to load on the "Failed to load plugins" page, reports the culprit to the tray, and offers one-click disable+restart to recover DSH.
- **Single exe, zero dependencies** (P/Invoke over the OS-shipped winsqlite3.dll); CLI control plane (dsh-tray-cli) for scripting; MIT.

## Verification
Every submission is checked against its own source. The dsh-tray README documents the features, deployment (build.cmd produces the two exes), CLI reference, and the sentinel mechanism. Releases v1.0.0 → v1.2.1 ship zh/en builds + sentinel.zip.

Self-check: the repo runs dsh-tray-cli selftest (71 sandboxed unit tests) and the recovery loop was verified end-to-end on a throwaway port.

Description line (in the PR): Windows system-tray guardian for DeepSeek Harness: launch/stop/restart the dsh service, multi-profile port bindings, snapshot-based quick recovery, plugin enable/disable, SQLite version ledger, and a client sentinel that detects a plugin failing to load, disables it and restores DSH.