### PR TITLE
docs: add dsh-product-subagent-console

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Management panel: Settings → Plugins.
 - [bpc-oss/dsh-fork-to-preset](https://github.com/bpc-oss/dsh-fork-to-preset) - Fork any session into a different agent preset from the conversation header: a preset picker creates a new child session mounted on the chosen preset, inheriting the source session's completed turns.
 - [qwert702/dsh-commander](https://github.com/qwert702/dsh-commander) - Commander mode for DSH Web: inject protocol briefs into the session title bar, parse task blocks from model replies and auto-execute them, separating strategy from execution; activated via a badge button.
 
-- [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - Conversation-native multi-Agent planning and observability workbench that maps approved task nodes to real child sessions, compares plans with runtime attempts, previews scoped recovery, and exports reusable run evidence.
+- [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - Conversation-level multi-agent workbench for editable task planning, real child-session observation, plan-versus-runtime comparison, and evidence-backed recovery previews; tested with DSH 0.1.1-rc.2.
 
 ## Context & Search
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Management panel: Settings → Plugins.
 - [bpc-oss/dsh-fork-to-preset](https://github.com/bpc-oss/dsh-fork-to-preset) - Fork any session into a different agent preset from the conversation header: a preset picker creates a new child session mounted on the chosen preset, inheriting the source session's completed turns.
 - [qwert702/dsh-commander](https://github.com/qwert702/dsh-commander) - Commander mode for DSH Web: inject protocol briefs into the session title bar, parse task blocks from model replies and auto-execute them, separating strategy from execution; activated via a badge button.
 
+- [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - Conversation-native multi-Agent planning and observability workbench that maps approved task nodes to real child sessions, compares plans with runtime attempts, previews scoped recovery, and exports reusable run evidence.
+
 ## Context & Search
 
 - [zoahdev/dsh-github-intelligence](https://github.com/zoahdev/dsh-github-intelligence) - Read-only developer-intelligence tools across 16 ecosystems (GitHub, GitLab, Gitee, npm, PyPI, crates.io, Docker Hub, Hugging Face, Hacker News, Stack Overflow, Reddit, dev.to, RubyGems, NuGet, Go, ArXiv) with TTL caching and no API key.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,6 +115,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [bpc-oss/dsh-fork-to-preset](https://github.com/bpc-oss/dsh-fork-to-preset) - 在对话页头将任意会话分叉到另一 Agent 预设：通过预设选择器创建挂载到所选预设的新子会话，并继承源会话已完成的轮次。
 - [qwert702/dsh-commander](https://github.com/qwert702/dsh-commander) — DSH 网页端指挥官模式插件：会话标题栏一键注入协议简报，解析模型回复中的任务块并自动执行，让策略层与执行层分离；通过徽章按钮激活/停用。
 
+- [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - 对话内多 Agent 方案设计与运行观察工作台：将已批准任务节点映射到真实子会话，对照计划与实际执行，预览限定范围的恢复，并导出可复用运行证据。
+
 ## Context & Search
 
 - [zoahdev/dsh-github-intelligence](https://github.com/zoahdev/dsh-github-intelligence) - 只读开发者情报工具：16 大生态（GitHub、GitLab、Gitee、npm、PyPI、crates.io、Docker Hub、Hugging Face、Hacker News、Stack Overflow、Reddit、dev.to、RubyGems、NuGet、Go、ArXiv）统一查询，带 TTL 缓存，无需 API Key。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -115,7 +115,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [bpc-oss/dsh-fork-to-preset](https://github.com/bpc-oss/dsh-fork-to-preset) - 在对话页头将任意会话分叉到另一 Agent 预设：通过预设选择器创建挂载到所选预设的新子会话，并继承源会话已完成的轮次。
 - [qwert702/dsh-commander](https://github.com/qwert702/dsh-commander) — DSH 网页端指挥官模式插件：会话标题栏一键注入协议简报，解析模型回复中的任务块并自动执行，让策略层与执行层分离；通过徽章按钮激活/停用。
 
-- [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - 对话内多 Agent 方案设计与运行观察工作台：将已批准任务节点映射到真实子会话，对照计划与实际执行，预览限定范围的恢复，并导出可复用运行证据。
+- [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - 面向 DSH 对话的多 Agent 工作台：支持可编辑任务方案、真实子会话观测、计划与实际运行对照，以及基于证据的恢复预览；已使用 DSH 0.1.1-rc.2 测试。
 
 ## Context & Search
 


### PR DESCRIPTION
## Summary

Add `dsh-product-subagent-console` to **Agents & Orchestration** in both English and Chinese.

The entry is intentionally one line per language and describes the current v0.9 capabilities: conversation-native multi-Agent planning, real child-session observation, plan-versus-runtime comparison, scoped recovery preview, and reusable run evidence.

## Source verification

- Repository: https://github.com/Jokasa7/dsh-product-subagent-console
- Release: https://github.com/Jokasa7/dsh-product-subagent-console/releases/tag/v0.9.0
- DSH compatibility: 0.1.1-rc.2
- Root `package.json` declares a DSH bundle and the Cordis patch is committed
- README documents Release `.tgz` installation for Web and Desktop profiles

No generated catalog files or unrelated sections are changed.