### PR TITLE
Add dsh-file-convert (local-first file conversion plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ Management panel: Settings → Plugins.
 - [dsh-cron-parse](https://github.com/ZhijiangTang/dsh-cron-parse) - Parses cron expressions into human-readable text and previews upcoming run times.
 - [dsh-dead-links](https://github.com/ZhijiangTang/dsh-dead-links) - Scans Markdown files for dead http(s) links.
 - [dsh-fetch-file](https://github.com/ZhijiangTang/dsh-fetch-file) - Downloads a URL into the workspace as a file, with a path fence, streaming, and a 200 MB cap.
+- [dsh-file-convert](https://github.com/zzy-12345678/dsh-file-convert) - Local-first file conversion: 26 conversions across images, PDF (with OCR and experimental PDF→DOCX), data, audio/video and office docs; 7 tools, all local, no API keys.
 - [dsh-fmt](https://github.com/ZhijiangTang/dsh-fmt) - Formats and validates JSON/YAML/TOML/SQL, with line-and-column error locations.
 - [dsh-handoff](https://github.com/ZhijiangTang/dsh-handoff) - Exports the current session as a deterministic Markdown handoff document.
 - [dsh-http](https://github.com/ZhijiangTang/dsh-http) - Structured HTTP request tool: returns status, duration, and size, with basic/bearer auth helpers.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -786,6 +786,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-cron-parse](https://github.com/ZhijiangTang/dsh-cron-parse) - 解析 cron 表达式为人类可读描述，并预览未来运行时间。
 - [dsh-dead-links](https://github.com/ZhijiangTang/dsh-dead-links) - 检查 Markdown 文档中的失效 http(s) 链接。
 - [dsh-fetch-file](https://github.com/ZhijiangTang/dsh-fetch-file) - 将 URL 下载为工作区文件：路径围栏、流式、200MB 上限。
+- [dsh-file-convert](https://github.com/zzy-12345678/dsh-file-convert) - 本地优先的格式转换：覆盖图片、PDF（含 OCR 与实验性 PDF→DOCX）、数据、音视频与办公文档共 26 种转换；7 个工具，全本地执行，无需 API Key。
 - [dsh-fmt](https://github.com/ZhijiangTang/dsh-fmt) - JSON/YAML/TOML/SQL 格式化与校验，错误带行列定位。
 - [dsh-handoff](https://github.com/ZhijiangTang/dsh-handoff) - 将当前会话一键导出为确定性 Markdown 交接文档。
 - [dsh-http](https://github.com/ZhijiangTang/dsh-http) - 结构化 HTTP 请求工具：返回状态码、耗时与大小，支持 basic/bearer 认证。


### PR DESCRIPTION
## What

Adds [dsh-file-convert](https://github.com/zzy-12345678/dsh-file-convert) to the **Tools & Utilities** section (both English and Chinese READMEs), alphabetically after dsh-fetch-file.

## Why

- DSH bundle plugin (`dsh.bundle.patch`), also listed under the public `dsh-plugin` topic
- Local-first: 26 conversions across images, PDF (raster, text, OCR, experimental PDF→DOCX), data (JSON/YAML/CSV), audio/video and office documents — no API keys, no uploads, no servers
- 7 tools: `convert_file` (page ranges, OCR), `batch_convert`, `inspect_file` (scanned-PDF detection), `list_conversions`, `optimize_file` (target-size compression), `install_media_dependencies` / `install_ocr_dependencies` (explicit, consented dependency downloads)
- MIT, CI on ubuntu/windows/macos, zero external binaries for images/PDF/data

Entry follows the one-line factual style of the surrounding list.