### PR TITLE
docs: add dsh-fetch-timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,6 +484,7 @@ Management panel: Settings → Plugins.
 - [dsh-plugin-rollout-scout](https://github.com/SpookySandwich/dsh-plugin-rollout-scout) - Detects which conversation model your account is being served: launches concurrent throwaway probe conversations, scores each streaming chain-of-thought by how its paragraphs open, and cancels probes that read as the older model within seconds.
 - [openllmsh/dsh](https://github.com/openllmsh/dsh) - Routes the harness through the OpenLLM gateway: a pure-config Cordis patch that adds an `openllm` provider to the in-box pi-ai adapter pointed at the local daemon (`127.0.0.1:8787/v1`, no API key held by dsh) and registers the `openllm mcp` stdio server (openllm, claude-context, supermemory tool groups).
 - [lynkr-dsh-plugin](https://github.com/veerareddyvishal144/lynkr-dsh-plugin) - Registers Lynkr, a self-hosted tier-routing LLM gateway, as a custom OpenAI-compatible provider: classifies each request's difficulty and routes it to the cheapest model that can handle it, across 15+ providers (Anthropic, OpenAI, Azure, Bedrock, Vertex, OpenRouter, Ollama, DeepSeek, and more).
+- [dsh-fetch-timeouts](https://github.com/d3vmeh/dsh-fetch-timeouts) - Raises Node's HTTP headers/body timeouts for the whole DSH process (default 30 min, proxy-aware) so Ollama and LM Studio models that stay silent while thinking or generating a large tool call are not cut off at 5 minutes; replaces the node_modules undici patch.
 
 ## Git & Engineering
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -476,6 +476,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-browser-vision](https://github.com/tristan-mcinnis/dsh-browser-vision) - 视觉浏览器工具：以 browser-use 通过 CDP 驱动真实 Chrome，并用 deepseek-v4-flash-vision-exp 读取页面，可识别 canvas 上绘制的文字、图片中烧录的文字与图表中的数值；支持按调用方提供的 JSON Schema 返回结构化结果，并统计每次运行的 token 成本
 - [openllmsh/dsh](https://github.com/openllmsh/dsh) - 将 DeepSeek Harness 接入 OpenLLM 网关：纯配置的 Cordis patch，为内置 pi-ai 适配器添加指向本地守护进程（`127.0.0.1:8787/v1`，dsh 侧不持有 API Key）的 `openllm` provider，并注册 `openllm mcp` stdio 服务（openllm、claude-context、supermemory 工具组）。
 - [lynkr-dsh-plugin](https://github.com/veerareddyvishal144/lynkr-dsh-plugin) - 将 Lynkr（一个自托管的多提供商分级路由 LLM 网关）注册为自定义 OpenAI 兼容 provider：根据每个请求的实际难度分类，并路由到能胜任该任务的最便宜模型，覆盖 15+ 提供商（Anthropic、OpenAI、Azure、Bedrock、Vertex、OpenRouter、Ollama、DeepSeek 等）。
+- [dsh-fetch-timeouts](https://github.com/d3vmeh/dsh-fetch-timeouts) - 把整个 DSH 进程的 Node HTTP headers/body 超时调大（默认 30 分钟，支持代理环境变量），让 Ollama、LM Studio 这类在思考或生成大段工具参数时长时间不返回数据的本地模型不再在 5 分钟处被掐断；替代手工修改 node_modules 的 undici 补丁。
 
 ## Git & Engineering
 


### PR DESCRIPTION
Adds dsh-fetch-timeouts to Models & Inference in both README.md and README.zh-CN.md.

Raises Node's HTTP headers/body timeouts for the whole DSH process so slow local models (Ollama, LM Studio) are not cut off at 5 minutes; proxy-aware under NODE_USE_ENV_PROXY.

Repo: https://github.com/d3vmeh/dsh-fetch-timeouts
npm: https://www.npmjs.com/package/dsh-fetch-timeouts
Announcement: https://github.com/deepseek-ai/deepseek-harness/discussions/5124