### PR TITLE
docs: add sofagent

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,6 +563,7 @@ Management panel: Settings → Plugins.
 - [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) - LLM auto-review approval answerer for sandbox escalations under the `'auto'` policy: a deterministic filter plus a clean-context reviewer model decide without a human prompt, fail-closed on every error path; requires a patched harness core (included in core-patches/).
 - [dsh-capmark-gate](https://github.com/taltara/capmark) - Holds an agent to a declared capability manifest: a Markdown `CAP.md` states what a plugin may do, and the gate masks the agent's tool view with `tools.restrict()` and judges every call at `tools/pre-execute`; scopes finer than a tool name are linted as advisory rather than presented as enforcement.
 - [dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet) - Brokered SaaS access: four tools call approved platforms through a credential broker, minting a short-lived assertion per call, so no API key is stored on the machine and every call is owner-approvable, revocable, and audited.
+- [sofagent](https://github.com/KongFangXun/sofagent) - Commit-time agent governance harness: 24 deterministic audit rules over git diffs (secrets, out-of-scope edits, blind modifications, prompt-injection traces), HMAC-chained tamper-evident history, and a 9-plugin DSH family (audit / gate / rollback / inject / ontology / evolve / commons / daemon / fde) distributed via SkillHub.
 
 ## Output & Deliverables
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -560,6 +560,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [accpowered/dsh-auto-review](https://github.com/accpowered/dsh-auto-review) - 沙箱升级请求的 LLM 自动审查审批应答器（`'auto'` 策略下）：确定性过滤 + 清洁上下文审查模型裁决，无需人工提示，错误路径一律 fail-closed；需要打过补丁的 harness 核心（补丁见 core-patches/）。
 - [dsh-capmark-gate](https://github.com/taltara/capmark) - 按声明的能力清单约束 agent：用 Markdown 编写的 `CAP.md` 声明插件可做什么，插件据此用 `tools.restrict()` 收窄 agent 可见的工具集，并在 `tools/pre-execute` 上裁决每次调用；比工具名更细的 scope 会被标记为仅供审计，而非当作强制边界。
 - [dsh-agentvalet](https://github.com/AgentValet/dsh-agentvalet) - 代理式 SaaS 访问：四个工具经凭据代理调用已授权平台，每次调用签发短期断言，机器上不存任何 API key，每次调用都可由所有者审批、撤销并留存审计。
+- [sofagent](https://github.com/KongFangXun/sofagent) - 提交时 agent 治理 harness：24 条确定性规则审计 git diff（密钥泄漏、越权改动、盲目修改、注入痕迹），HMAC 链防篡改历史，9 插件 DSH 家族（audit / gate / rollback / inject / ontology / evolve / commons / daemon / fde）经 SkillHub 分发。
 
 ## Output & Deliverables
 


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to **Security & Governance** in both README.md and README.zh-CN.md (same entry, translated description, per contributing guide).

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

sofagent is a commit-time governance harness for AI coding agents: 24 deterministic audit rules over git diffs (secrets, out-of-scope edits, blind modifications, prompt-injection traces), HMAC-chained tamper-evident audit history, and a 9-plugin DSH family (audit / gate / rollback / inject / ontology / evolve / commons / daemon / fde) under `engine/dsh-plugins/cordis-plugin-sofagent-*`, distributed via SkillHub (`skillhub install cordis-plugin-sofagent-*`).

Entry format follows the standard: repository + one-line factual description + link, no fluff. Also available as a GitHub Action ([marketplace](https://github.com/marketplace/actions/sofagent)) and MCP server.

Related listings: [punkpeye/awesome-mcp-servers #13312](https://github.com/punkpeye/awesome-mcp-servers/pull/13312), [Glama](https://glama.ai/mcp/servers/KongFangXun/sofagent), [agentrust-io/awesome-ai-governance #89](https://github.com/agentrust-io/awesome-ai-governance/pull/89).