### PR TITLE
docs: add liyupi/ai-guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Management panel: Settings → Plugins.
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue aggregation hub.
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - Curated navigation of community meme plugins (skins, desktop pets, mini-games), bilingual.
 - [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 173 English-canonical, source-backed guides with 202 localized documents, an 82-resource Agent-first [Awesome resource map](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html), local-browser [Install Doctor](https://sandbaseai.github.io/deepseek-harness-handbook/install-doctor.html), and [Failure Router](https://sandbaseai.github.io/deepseek-harness-handbook/diagnose.html).
+- [liyupi/ai-guide](https://github.com/liyupi/ai-guide) - Chinese Vibe Coding handbook with a dedicated DeepSeek Harness section: getting started, server deployment, agent presets, minimal-mode field test, and curated plugins.
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI-compatible endpoint with free DeepSeek V4 Pro/Flash daily quotas; point DEEPSEEK_BASE_URL at it, no payment info required.
 - [DeepSeek](https://deepseek.com) - Official site.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -816,6 +816,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue 聚合仓库
 - [dsh-meme-hub](https://github.com/the-beating-light-of-the-nail/dsh-meme-hub) - 社区整活插件导航（皮肤/桌宠/小游戏），中英双语
 - [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 从 Agent 视角讲解 DSH 运行、扩展与排障的来源可追溯手册，提供 162 篇英文 canonical 指南、189 份多语言文档、可搜索的 [Awesome 资源地图](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html)，以及 Install Doctor 和 Failure Router 速查工具
+- [liyupi/ai-guide](https://github.com/liyupi/ai-guide) - 中文 Vibe Coding 教程，设有 DeepSeek Harness 专题：保姆级入门、服务器部署、Agent 预设详解、极简模式实测与精选插件推荐。
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI 兼容接入点，提供免费的 DeepSeek V4 Pro/Flash 每日配额；把 DEEPSEEK_BASE_URL 指向它即可，无需支付信息。
 - [DeepSeek](https://deepseek.com) - 官方入口
 


### PR DESCRIPTION
## What this adds

One entry in the **Related** section, added to both `README.md` and `README.zh-CN.md`, placed next to the DeepSeek Harness Handbook so documentation-type resources stay grouped.

```markdown
- [liyupi/ai-guide](https://github.com/liyupi/ai-guide) - Chinese Vibe Coding handbook with a dedicated DeepSeek Harness section: getting started, server deployment, agent presets, minimal-mode field test, and curated plugins.
```

## About the resource

To be upfront: this is not a DSH plugin or an ecosystem member project, so it does not belong in any of the plugin categories. It is a general Chinese Vibe Coding handbook that contains a dedicated DeepSeek Harness section — which is why I put it under **Related**, alongside the Handbook entry that is also documentation rather than a plugin.

The DSH-specific content currently covers:

- DeepSeek Harness 保姆级入门教程 (getting started)
- DeepSeek Harness 服务器部署教程 (server deployment)
- DeepSeek Harness Agent 预设详解 (agent presets)
- DeepSeek Harness 极简模式实测 (minimal-mode field test)
- DeepSeek Harness 精选插件推荐 (curated plugins)
- Harness Engineering 保姆级教程 (harness engineering walkthrough)
- A three-model comparison benchmarked through DSH as the unified harness

The repository has 19k+ stars, is free with no paywall, and ships Simplified Chinese, Traditional Chinese and English versions. If you feel a general handbook is out of scope for this list even under Related, feel free to close — no hard feelings.

Disclosure: this is my own project.

## Checklist

- [x] Real repository, live link
- [x] One-line factual description, no marketing, no badges or screenshots
- [x] Both `README.md` and `README.zh-CN.md` updated in the same PR with translated descriptions
- [x] Commit title follows `docs: add <repo>`

Made with [Cursor](https://cursor.com)