### PR TITLE
fix: update dsh-remote repo link to mrRisega

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,7 +399,7 @@ Management panel: Settings → Plugins.
 
 ## Browser & Remote
 
-- [mrgaoang/dsh-remote](https://github.com/mrgaoang/dsh-remote) - Reverse-proxy gateway to control the DSH Web UI from a phone browser with full feature coverage (incl. privileged methods): loopback masquerading, WebSocket passthrough, login rate limiting, optional TLS, LAN or public reverse-proxy deployment.
+- [mrRisega/dsh-remote](https://github.com/mrRisega/dsh-remote) - Reverse-proxy gateway to control the DSH Web UI from a phone browser with full feature coverage (incl. privileged methods): loopback masquerading, WebSocket passthrough, login rate limiting, optional TLS, LAN or public reverse-proxy deployment.
 - [dsh-voice-gate](https://github.com/yangfei222666-9/dsh-voice-gate) - Voice-first mobile gate into DSH: a zero-dependency Python service (port 3081) with a PWA page that sends voice or text to the current session, token auth, launchd autostart, and a Tailscale HTTPS recipe.
 - [dsh-browser-panel](https://github.com/dsh-external/dsh-browser-panel) - Headed browser embedded in the WebUI, model-driven (Codex-style, zero vision deps).
 - [dsh-builtin-browser](https://github.com/wqty123/dsh-browser) - Shared real browser for DSH: a visible browser window the human can take over, driven by the agent over CDP (snapshot/execute/content/tab management).


### PR DESCRIPTION
The repository `mrgaoang/dsh-remote` was renamed to `mrRisega/dsh-remote`. The listed link still resolves (301), but the displayed name and link are stale.

This PR updates only the link and display text for `dsh-remote`:
- `[mrgaoang/dsh-remote](https://github.com/mrgaoang/dsh-remote)` → `[mrRisega/dsh-remote](https://github.com/mrRisega/dsh-remote)`

Description left untouched.