### PR TITLE
docs: add duyanta123/dsh-repo-scanner (Plugin Ecosystem & Development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,8 @@ Management panel: Settings → Plugins.
 - [dsh-blueprint](https://github.com/taltara/mddl-harness) - Blueprint tab for the Web client: reads the config the harness actually booted, lints the running tree, and writes a `cordis.patch.yml` overlay behind a marker-delimited block with snapshots and one-click restore. Refuses to write a row naming a package the profile cannot load, since that stops the harness booting rather than disabling one entry.
 - [LLYlab/DSHEssentialTools](https://github.com/LLYlab/DSHEssentialTools) - A permanent DeepSeek Harness plugin: project run & code viewer, program snapshots, a VTD conversation tree (edit / retry / branches) with message micro-versions, plus a DET feature manager and global plugin control.
 
+- [duyanta123/dsh-repo-scanner](https://github.com/duyanta123/dsh-repo-scanner) - Read-only repository fact scanner kernel for analysis plugins: deterministic probe / file index / modules / dependencies / entry points / symbols / graphs and git facts over a stable JSON schema (CLI + library + skill runbook).
+
 ## Runtime & Operations
 
 - [ianho7/dsh-port-inspector](https://github.com/ianho7/dsh-port-inspector) - Windows local development port attribution and safe handling for verified DSH services.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -699,6 +699,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-score](https://github.com/PerryLink/dsh-score) - DSH 插件多维质量评分：五维（安装成功率/维护活跃度/文档完整性/安全扫描/协议合规）评分卡与总分，/score 命令与排行榜报告；安装证据预留消费 dsh-test-drive 的结构化实测结果。
 - [dsh-blueprint](https://github.com/taltara/mddl-harness) - Web 客户端的 Blueprint 标签页：读取 harness 实际启动的配置、对运行中的插件树做 lint，并在带标记的托管块内写入 `cordis.patch.yml` 覆盖层，支持快照与一键恢复。若某行引用了 profile 无法加载的包，则拒绝写入——那会导致整个 harness 无法启动，而不只是禁用一行。
 
+- [duyanta123/dsh-repo-scanner](https://github.com/duyanta123/dsh-repo-scanner) - 只读仓库事实扫描内核：为分析型插件提供可复现的仓库探测、文件索引、模块、依赖、入口点、符号与 Git 变更基线等硬事实（CLI + 库接口 + 技能 runbook）。
+
 ## Runtime & Operations
 
 - [ianho7/dsh-port-inspector](https://github.com/ianho7/dsh-port-inspector) - Windows 本地开发端口来源追踪与已验证 DSH 服务的安全处理。


### PR DESCRIPTION
Adds one entry (en + zh, same placement) to **Plugin Ecosystem & Development**:

- [duyanta123/dsh-repo-scanner](https://github.com/duyanta123/dsh-repo-scanner) — read-only repository fact scanner kernel shared by analysis plugins (arch-doc / dsh-refactor-insight / upcoming dsh-change-impact / dsh-test-insight).

Context:
- Declares `dsh.bundle.patch` (config-tree `- insert:` manifest) — installable via `dsh plugin --profile web add github:duyanta123/dsh-repo-scanner`; skills registered via the official `@deepseek-ai/dsh-skill-filesystem` provider.
- v0.1.0 tagged 2026-09-02; CI green (ubuntu + windows × Node 18/20/22; 33 tests incl. an executable security-audit suite enforcing the no-write / no-subprocess / no-network red lines).
- Sibling plugins of the same author are already listed (arch-doc, dsh-preset-scaffold, dsh-refactor-insight, dsh-data-insight).