### PR TITLE
docs: add dsh-chinese-poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,7 @@ Management panel: Settings → Plugins.
 
 ## Fun & Lifestyle
 
+- [dsh-chinese-poetry](https://github.com/runcat-tommy/dsh-chinese-poetry) - Token-free Chinese classical-poetry tab in the DSH conversation view: search, filters, 飞花令, daily poem, favorites, festival topics, share-card image, and AI explanation via your own DSH session.
 - [dsh-whale-companion](https://github.com/LeemanCheung/dsh-whale-companion) - Draggable whale companion with local progression, achievements, skins, and privacy-safe activity tracking.
 - [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) - Whale-girl desktop pet for the DSH Web UI: pat-to-raise growth, work-state poses, 494 dialogue lines and 30 achievements with a built-in settings panel; local-first, zero telemetry.
 - [dsh-clippy](https://github.com/sjh9714/clippy-harness) - Clippy revived as an office assistant pet that reacts to real agent state, with a classic "illegal operation" dialog on failed turns.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -622,6 +622,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 ## Fun & Lifestyle
 
+- [dsh-chinese-poetry](https://github.com/runcat-tommy/dsh-chinese-poetry) - 免 token 诗词查询插件：会话页头「诗词」标签页，支持搜索/筛选/飞花令/每日一首/收藏/节日专题/分享卡片图，AI 解读复用 DSH 会话（不自动提交）。
 - [dsh-whale-companion](https://github.com/LeemanCheung/dsh-whale-companion) - 可拖拽的鲸鱼伙伴，提供本地成长、成就、皮肤和隐私安全的活动统计。
 - [dsh-whale-musume](https://github.com/Sutera-Diffusus/dsh-whale-musume) - 元气鲸鱼娘桌宠：摸头养成、工作状态联动、494 条台词与 30 项成就，自带设置面板，全本地、零遥测。
 - [dsh-clippy](https://github.com/sjh9714/clippy-harness) - Clippy 复活为办公室助理宠物：对真实 agent 状态做出反应，失败回合弹出经典「非法操作」对话框。


### PR DESCRIPTION
Add dsh-chinese-poetry to the Fun & Lifestyle section (both README.md and README.zh-CN.md).

Token-free Chinese classical-poetry tab in the DSH conversation view: search, filters, 飞花令, daily poem, favorites, festival topics, share-card image; AI explanation reuses your own DSH session and never auto-submits.