### PR TITLE
Add weibaohui/dsh-continue (auto-resume)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ Management panel: Settings → Plugins.
 
 - [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - Conversation-level multi-agent workbench for editable task planning, real child-session observation, plan-versus-runtime comparison, and evidence-backed recovery previews; tested with DSH 0.1.1-rc.2.
 
+- [weibaohui/dsh-continue](https://github.com/weibaohui/dsh-continue) - Auto-resume for interrupted agent sessions: an ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into backoff retry, model switch, resume after compaction, or stop-loss notification, with a visual rule editor and activity log.
+
 ## Context & Search
 
 - [zoahdev/dsh-github-intelligence](https://github.com/zoahdev/dsh-github-intelligence) - Read-only developer-intelligence tools across 16 ecosystems (GitHub, GitLab, Gitee, npm, PyPI, crates.io, Docker Hub, Hugging Face, Hacker News, Stack Overflow, Reddit, dev.to, RubyGems, NuGet, Go, ArXiv) with TTL caching and no API key.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -119,6 +119,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 
 - [dsh-product-subagent-console](https://github.com/Jokasa7/dsh-product-subagent-console) - 面向 DSH 对话的多 Agent 工作台：支持可编辑任务方案、真实子会话观测、计划与实际运行对照，以及基于证据的恢复预览；已使用 DSH 0.1.1-rc.2 测试。
 
+- [weibaohui/dsh-continue](https://github.com/weibaohui/dsh-continue) - 自动续跑：agent 会话中断后自动续上，规则表按失败类型（限流/额度/鉴权/上下文超限/崩溃孤儿）路由到退避重试、换模型、压缩上下文后继续或止损通知，规则可视化编辑，全程活动日志。
+
 ## Context & Search
 
 - [zoahdev/dsh-github-intelligence](https://github.com/zoahdev/dsh-github-intelligence) - 只读开发者情报工具：16 大生态（GitHub、GitLab、Gitee、npm、PyPI、crates.io、Docker Hub、Hugging Face、Hacker News、Stack Overflow、Reddit、dev.to、RubyGems、NuGet、Go、ArXiv）统一查询，带 TTL 缓存，无需 API Key。


### PR DESCRIPTION
Adds **weibaohui/dsh-continue** (auto-resume for interrupted agent sessions) to **Agents & Orchestration**, with the matching Chinese entry in `README.zh-CN.md`.

An ordered rule table routes by failure type (rate limit, quota, auth, context overflow, crashed orphan) into automatic backoff retry, model switch, resume after context compaction, or a stop-loss notification — with a visual rule editor and a full activity log.

- npm: [@weibaohui/dsh-continue](https://www.npmjs.com/package/@weibaohui/dsh-continue) (v0.3.0), `package.json` declares `dsh.bundle`; repo has the `dsh-plugin` topic
- Install: `dsh plugin --profile web add @weibaohui/dsh-continue`
- Demo: https://github.com/weibaohui/dsh-continue/blob/main/docs/demo.gif
