### PR TITLE
Add weibaohui/dsh-settings-ui (settings window customization)

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,8 @@ Management panel: Settings → Plugins.
 - [dsh-workspace-sort](https://github.com/Moonshile/moonshile-dsh-plugins) - Re-sorts sidebar workspaces by last activity once per day; stable order within the day.
 - [dsh-theme-manager](https://github.com/runcat-tommy/dsh-theme-manager) - Two-level theme manager for the DSH Web UI: pick a culture / scene, a national flag, a developer palette, or a bold high-contrast pairing first, then a concrete style (58 built-in palettes, light & dark).
 
+- [weibaohui/dsh-settings-ui](https://github.com/weibaohui/dsh-settings-ui) - Customizes the DSH native settings window: preset or custom sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating ball for quick access; saved in the local browser.
+
 ## Dashboards & Session UX
 
 - [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) - Turn-based time tracking from session logs: per-day/project/provider/source rollups, tool calls, failures, TTFT (CLI + `timesheet` tool).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -291,6 +291,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-workspace-sort](https://github.com/Moonshile/moonshile-dsh-plugins) - 侧边栏工作区每日按最近活动排序一次，当天顺序稳定。
 - [dsh-theme-manager](https://github.com/runcat-tommy/dsh-theme-manager) - DSH Web 两级主题管理器：先选文化 / 场景、国旗、开发者配色或强烈对比配色，再选具体风格（内置 58 套配色，含浅色 / 深色底版）。
 
+- [weibaohui/dsh-settings-ui](https://github.com/weibaohui/dsh-settings-ui) - 设置界面自定义：调整原生设置窗口大小（全屏/预置/自定义宽高）、背景透明度与背景（主题/颜色/图片），悬浮球即开即调，存本机浏览器。
+
 ## Dashboards & Session UX
 
 - [zoahdev/dsh-timesheet](https://github.com/zoahdev/dsh-timesheet) - 从会话日志做基于 turn 的时间跟踪：按天/项目/供应商/来源汇总、工具调用数、失败率与 TTFT（CLI + `timesheet` 工具）。


### PR DESCRIPTION
Adds **weibaohui/dsh-settings-ui** (settings-window customization) to **UI, Themes & Interaction**, with the matching Chinese entry in `README.zh-CN.md`.

Customizes the DSH native settings window: preset or custom window sizes, fullscreen, background transparency, and theme, solid-color, or image backgrounds, with a floating ball for quick access. Light and dark themes store separate colors; saved in the local browser.

- npm: [@weibaohui/dsh-settings-ui](https://www.npmjs.com/package/@weibaohui/dsh-settings-ui) (v0.2.0), `package.json` declares `dsh.bundle`; repo has the `dsh-plugin` topic
- Install: `dsh plugin --profile web add @weibaohui/dsh-settings-ui`
- Demo: https://github.com/weibaohui/dsh-settings-ui/blob/main/docs/demo.gif
