### PR TITLE
Add weibaohui/context-razor (context trimmer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Management panel: Settings → Plugins.
 - [dsh-context-budget](https://github.com/d3vmeh/dsh-context-budget) - Keeps a local model's context at a size the GPU handles well: measures prefill speed on every request and, before each step, warns or compacts early on a hard token ceiling, an observed time-to-first-token budget, or a predicted cold-prefill budget; /context-budget shows the numbers and the cost of compacting now.
 - [dsh-personal-directive](https://github.com/PerryLink/dsh-personal-directive) - Personal directives for the agent: system-prompt injection, tools, and a top-bar runtime toggle with replaceable neutral placeholder instructions.
 
+- [weibaohui/context-razor](https://github.com/weibaohui/context-razor) - Context trimmer: lists the current session's context entries with role, preview and ≈token estimate (cl100k), highlights over-threshold items, and removes selected entries exactly without LLM summarization.
+
 ## Memory & Knowledge
 
 - [zilliztech/memsearch](https://github.com/zilliztech/memsearch/tree/main/plugins/dsh) - Shared Markdown memory for DSH and other coding agents, with automatic capture, pre-step context injection, searchable recall, and a review panel.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -154,6 +154,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-context-budget](https://github.com/d3vmeh/dsh-context-budget) - 让本地模型的上下文保持在 GPU 能高效处理的规模：每次请求测量 prefill 速度，在每一步之前按硬性 token 上限、实测首 token 时间预算或预测的冷 prefill 预算发出警告或提前压缩；/context-budget 显示实时数据和立即压缩的代价。
 - [dsh-personal-directive](https://github.com/PerryLink/dsh-personal-directive) - 个人指令插件：系统提示词注入、工具与顶部运行时开关，内置可替换的中性占位指令。
 
+- [weibaohui/context-razor](https://github.com/weibaohui/context-razor) - 上下文剃刀：把当前会话上下文逐条列出（角色/预览/≈token 估算），超阈值标红，勾选后不经 LLM 精确裁剪，删了什么一目了然。
+
 ## Memory & Knowledge
 
 - [zilliztech/memsearch](https://github.com/zilliztech/memsearch/tree/main/plugins/dsh) - 供 DSH 与其他编程 Agent 共享的 Markdown 记忆，支持自动捕获、步骤前上下文注入、搜索召回与审阅面板。


### PR DESCRIPTION
Adds **weibaohui/context-razor** (context trimmer) to **Context & Search**, with the matching Chinese entry in `README.zh-CN.md`.

Context trimmer: lists the current session's context entries with role, preview and ≈token estimate (cl100k), highlights over-threshold items, and removes selected entries exactly without LLM summarization.

- npm: [@weibaohui/context-razor](https://www.npmjs.com/package/@weibaohui/context-razor) (v0.4.2), `package.json` declares `dsh.bundle`; repo has the `dsh-plugin` topic
- Install: `dsh plugin --profile web add @weibaohui/context-razor`
- Demo: https://github.com/weibaohui/context-razor/blob/main/docs/demo.gif
