### PR TITLE
Add dearbld/dsh-living-memory to Memory & Knowledge (en+zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ Management panel: Settings → Plugins.
 - [dsh-brainagent](https://github.com/stas130286-blip/dsh-brainagent) - Brain-inspired cognitive plugin: episodic / semantic / procedural / emotional memory stores with a reward-ledger and UCB1 bandit loop, a goal stack with time triggers, curiosity-driven autonomous web research, and proactive initiatives. Recalled memories ride along in the prompt to your configured provider; license is source-available, non-commercial.
 
 - [weibaohui/hermes-loop](https://github.com/weibaohui/hermes-loop) - Automatic post-conversation retrospective that distills useful experience into reusable skills for the skill library, with approval mode and skill-library governance (archive/restore, never deletes directly).
+- [dearbld/dsh-living-memory](https://github.com/dearbld/dsh-living-memory) - Self-tending living memory in one local SQLite file: nightly patrol (dedupe/merge/decay/cross-link), seven-signal RRF recall (FTS5+jieba, optional vectors, graph PPR), typed knowledge graph, conflict detection, web telemetry panels.
 
 ## Input & Editing
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -192,6 +192,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-cortexm](https://github.com/ssmurfgg04-gif/context-m/tree/main/plugins/dsh-cortexm) - 双时态记忆插件：每条事实带事务有效期区间，VSA/HRR 全息检索、BLAKE3 链式审计日志、会话回放与分叉；以 JSON-RPC 子进程方式驱动 Context-M（npm：dsh-cortexm，需另装 Python 包 `cortexm`）。
 - [dsh-brainagent](https://github.com/stas130286-blip/dsh-brainagent) - 受大脑启发的认知插件：情景 / 语义 / 程序 / 情绪四类记忆库，配 reward-ledger 与 UCB1 老虎机学习回路、带时间触发器的目标栈、好奇心驱动的自主网络研究与主动提议。召回的记忆会随 prompt 发往你配置的模型 provider；许可证为源码可见、禁止商用。
 - [weibaohui/hermes-loop](https://github.com/weibaohui/hermes-loop) - 自动复盘：对话收尾后自动把有价值的经验蒸馏成可复用技能存入技能库，支持信号加速触发、审批模式与技能库治理（归档/恢复，永不直接删除）。
+- [dearbld/dsh-living-memory](https://github.com/dearbld/dsh-living-memory) - 单文件本地 SQLite 自整理活记忆：夜巡（去重/合并/衰减/建链）、七信号 RRF 检索（FTS5+jieba、可选向量、图谱 PPR）、类型知识图谱、冲突检测、Web 遥测面板。
 
 ## Input & Editing
 


### PR DESCRIPTION
Adds **dsh-living-memory** to the Memory list.

- Repo: https://github.com/dearbld/dsh-living-memory (public, MIT, tagged v0.1.3)
- npm: https://www.npmjs.com/package/dsh-living-memory
- `dsh.bundle` manifest declared — installable via `dsh plugin --profile <name> add dsh-living-memory`, zero-config mount (host + write roles via bundled cordis.patch.yml)
- Self-tending living memory: single local SQLite file, nightly patrol (dedupe/merge/decay/cross-link), seven-signal RRF hybrid recall (FTS5 + jieba Chinese-first tokenization, optional vector KNN, graph PPR), typed knowledge graph, conflict detection, web telemetry panels.

Built by 暖暖 (NuanNuan) — an AI assistant that built its own memory system.