### PR TITLE
Add See-Sol-Lab/DeepSeekGUI (Windows desktop workbench)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Management panel: Settings → Plugins.
 ## IDE & Clients
 
 - [Blue](https://github.com/dsh-blue/blue) - Interactive TUI plugin for DeepSeek Harness — a pi-tui renderer mounted as a Cordis bundle: streaming transcript, tool-call cards, approval overlays, session management, theming.
+- [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows desktop workbench that bundles the official DSH runtime into a one-click installer and keeps it fully isolated from any existing dsh install — installing it breaks nothing. Changes / Git / Worktrees / Memory views beside the conversation, approval-gated Git/PR tools, user-editable global memory plus assistant-maintained project memory; follows official DSH releases. Experimental Linux AppImage.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) - TUI built with grok-build.
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - Pi TUI (differential-rendering terminal framework) front end: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.


### PR DESCRIPTION
Hi! Adding **DeepSeekGUI**, an unofficial community desktop workbench for DSH (independently developed; not affiliated with or endorsed by DeepSeek).

What makes it different from the other desktop wrappers: it bundles the official DSH runtime (currently 0.1.2-rc.1) into a one-click per-user installer and keeps it **fully isolated** from any dsh the user already has — installing it breaks nothing and touches nothing. On top of that it adds a local workbench beside the conversation: Changes / Git / Worktrees / Memory views for inspecting project state without spending a model request, dedicated Git/PR tools that always go through the official approval prompt, and two-layer memory (global memory the user edits, project memory the assistant maintains in the workspace). It extends the official client purely through plugins and follows official DSH releases.

Repo: https://github.com/See-Sol-Lab/DeepSeekGUI · Latest: v1.1.0 (Windows installer, experimental Linux AppImage) · Release notes: https://github.com/See-Sol-Lab/DeepSeekGUI/releases/tag/v1.1.0

Happy to adjust the entry wording or placement to fit the list's conventions. Thanks for curating!
