### PR TITLE
Add See-Sol-Lab/DeepSeekGUI (Windows desktop workbench)

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ Management panel: Settings → Plugins.
 ## IDE & Clients
 
 - [Blue](https://github.com/dsh-blue/blue) - Interactive TUI plugin for DeepSeek Harness — a pi-tui renderer mounted as a Cordis bundle: streaming transcript, tool-call cards, approval overlays, session management, theming.
+- [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows desktop workbench that bundles the official DSH runtime into a one-click installer and keeps it fully isolated from any existing dsh install — installing it breaks nothing. Changes / Git / Worktrees / Memory views beside the conversation, approval-gated Git/PR tools, user-editable global memory plus assistant-maintained project memory; follows official DSH releases. Experimental Linux AppImage.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) - TUI built with grok-build.
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - Pi TUI (differential-rendering terminal framework) front end: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,7 @@ Management panel: Settings → Plugins.
 ## IDE & Clients
 
 - [Blue](https://github.com/dsh-blue/blue) - Interactive TUI plugin for DeepSeek Harness — a pi-tui renderer mounted as a Cordis bundle: streaming transcript, tool-call cards, approval overlays, session management, theming.
-- [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows desktop workbench that bundles the official DSH runtime into a one-click installer and keeps it fully isolated from any existing dsh install — installing it breaks nothing. Changes / Git / Worktrees / Memory views beside the conversation, approval-gated Git/PR tools, user-editable global memory plus assistant-maintained project memory; follows official DSH releases. Experimental Linux AppImage.
+- [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows desktop workbench with a bundled DSH runtime and app-local settings and sessions, Changes / Git / Worktrees / Memory views, approval-gated Git/PR tools, and global and project memory. Experimental Linux AppImage.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) - TUI built with grok-build.
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - Pi TUI (differential-rendering terminal framework) front end: streaming markdown, thinking collapse, tool cards, slash commands, approval/question overlays, shared dsh session store.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -376,6 +376,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 ## IDE & Clients
 
 - [Blue](https://github.com/dsh-blue/blue) - DeepSeek Harness 交互式 TUI 插件：基于 Cordis bundle 的 pi-tui 渲染器，支持流式转录、工具调用卡片、审批浮层、会话管理与主题。
+- [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows 桌面工作台，内置 DSH 运行时，设置与会话保存在应用本地目录；提供变更、Git、Worktrees 与记忆视图、需审批的 Git/PR 工具，以及全局和项目记忆。另有实验性 Linux AppImage。
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code 风格全屏 TUI（流式展开/双击 Esc 回滚）
 - [dsh-grok-tui](https://github.com/chen-001/dsh-grok-tui) - grok-build TUI
 - [dsh-pi-tui](https://github.com/lqhl/dsh-pi-tui) - 基于 pi-tui 的 DeepSeek Harness 终端前端：流式 Markdown、thinking 折叠、工具卡片、slash 命令、审批/提问交互与 Web 会话共享


### PR DESCRIPTION
Hi! Adding **DeepSeekGUI**, an unofficial community desktop workbench for DSH (independently developed; not affiliated with or endorsed by DeepSeek).

What makes it different from the other desktop wrappers: it bundles the official DSH runtime (currently 0.1.2-rc.1) into a one-click per-user installer and keeps it **fully isolated** from any dsh the user already has — installing it breaks nothing and touches nothing. On top of that it adds a local workbench beside the conversation: Changes / Git / Worktrees / Memory views for inspecting project state without spending a model request, dedicated Git/PR tools that always go through the official approval prompt, and two-layer memory (global memory the user edits, project memory the assistant maintains in the workspace). It extends the official client purely through plugins and follows official DSH releases.

Repo: https://github.com/See-Sol-Lab/DeepSeekGUI · Latest: v1.1.0 (Windows installer, experimental Linux AppImage) · Release notes: https://github.com/See-Sol-Lab/DeepSeekGUI/releases/tag/v1.1.0

Happy to adjust the entry wording or placement to fit the list's conventions. Thanks for curating!
