### PR TITLE
docs: add PaperMachine to IDE & Clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,7 @@ Management panel: Settings → Plugins.
 - [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) - Full-control session management for DSH Web: archive, guaranteed physical delete (tombstone anti-resurrection), drag-and-drop workspace moves, conversation notifications, copy session ID and one-click record sync.
 ## IDE & Clients
 
+- [PaperMachine](https://github.com/SuperJJ007/papermachine) - Desktop data-analysis app built on DeepSeek Harness, running local Python and R with inspectable execution steps and chart/table provenance.
 - [Blue](https://github.com/dsh-blue/blue) - Interactive TUI plugin for DeepSeek Harness — a pi-tui renderer mounted as a Cordis bundle: streaming transcript, tool-call cards, approval overlays, session management, theming.
 - [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows desktop workbench with a bundled DSH runtime and app-local settings and sessions, Changes / Git / Worktrees / Memory views, approval-gated Git/PR tools, and global and project memory. Experimental Linux AppImage.
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code-style fullscreen TUI (streaming expand / double-Esc rollback).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -387,6 +387,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) - DSH Web 会话管理增强插件：归档管理 / 真实物理删除（墓碑防复活）/ 跨工作区拖拽搬移 / 对话通知 / 复制会话 ID / 一键同步记录。
 ## IDE & Clients
 
+- [PaperMachine](https://github.com/SuperJJ007/papermachine) - 基于 DeepSeek Harness 的桌面数据分析应用，在本机运行 Python 和 R，支持检查执行步骤及追溯图表和表格的来源。
 - [Blue](https://github.com/dsh-blue/blue) - DeepSeek Harness 交互式 TUI 插件：基于 Cordis bundle 的 pi-tui 渲染器，支持流式转录、工具调用卡片、审批浮层、会话管理与主题。
 - [DeepSeekGUI](https://github.com/See-Sol-Lab/DeepSeekGUI) - Windows 桌面工作台，内置 DSH 运行时，设置与会话保存在应用本地目录；提供变更、Git、Worktrees 与记忆视图、需审批的 Git/PR 工具，以及全局和项目记忆。另有实验性 Linux AppImage。
 - [dsh-cc-tui](https://github.com/dsh-external/dsh-cc-tui) - Claude Code 风格全屏 TUI（流式展开/双击 Esc 回滚）


### PR DESCRIPTION
Add PaperMachine to IDE & Clients in both English and Chinese READMEs.

PaperMachine is a desktop data-analysis application assembled from DeepSeek Harness plugins. It runs Python and R locally, exposes execution steps, and links figures and tables to their producing code, execution log, messages, and environment.

- Repository: https://github.com/SuperJJ007/papermachine
- Release: [papermachine-v0.1.1](https://github.com/SuperJJ007/papermachine/releases/tag/papermachine-v0.1.1)
- Installation: download the macOS Apple silicon / Intel DMG or experimental Windows x64 installer from the release page. First launch installs the Python/R environment; users supply their own DeepSeek API key. See [Quick start](https://github.com/SuperJJ007/papermachine#quick-start).
- License: MIT. The repository has the `dsh-plugin` topic.
- Verification: checked the public README, release assets, license and GitHub metadata; no fresh desktop installation or live model analysis was run for this directory submission.
- This is an early desktop application release; Windows is experimental/beta.

![PaperMachine desktop](https://raw.githubusercontent.com/SuperJJ007/papermachine/main/docs/media/hero.png)

[Execution trace demo](https://github.com/SuperJJ007/papermachine/blob/main/docs/media/trace.gif) · [Artifact provenance demo](https://github.com/SuperJJ007/papermachine/blob/main/docs/media/artifact.gif)

Validation: checked both entries and `git diff --check`. No existing PaperMachine entry or submission was found.
