### PR TITLE
Add dsh-capability-panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,6 +387,7 @@ Management panel: Settings → Plugins.
 - [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) - Peak/valley billing dock and usage analytics: token/cost/model stats, trend and token-mix charts, latest-20-turns records, global time/session/model filters.
 - [runcat-tommy/dsh-panda-calendar](https://github.com/runcat-tommy/dsh-panda-calendar) - Panda Calendar (熊猫日历) conversation-view tab: solar/lunar dates, ganzhi, Chinese zodiac, solar terms, festivals, China public holidays incl. make-up workdays, and multi-city weather; free data sources, no API key.
 - [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) - Full-control session management for DSH Web: archive, guaranteed physical delete (tombstone anti-resurrection), drag-and-drop workspace moves, conversation notifications, copy session ID and one-click record sync.
+- [dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) - See which skills and tools your agent can actually reach right now — true in-context state (loaded/truncated/evicted) and per-session switches.
 ## IDE & Clients
 
 - [Blue](https://github.com/dsh-blue/blue) - Interactive TUI plugin for DeepSeek Harness — a pi-tui renderer mounted as a Cordis bundle: streaming transcript, tool-call cards, approval overlays, session management, theming.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -385,6 +385,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) - 峰谷计费坞 + 用量分析仪表盘：token/成本/模型统计、成本趋势与 Token 结构图表、最近 20 轮明细，支持时间/会话/模型全局筛选与账户余额。
 - [runcat-tommy/dsh-panda-calendar](https://github.com/runcat-tommy/dsh-panda-calendar) - 熊猫日历会话视图标签页：公历/农历、干支、生肖、节气、传统与外国节日、中国法定节假日（含调休）、多城市天气；免费数据源，无需 API Key。
 - [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) - DSH Web 会话管理增强插件：归档管理 / 真实物理删除（墓碑防复活）/ 跨工作区拖拽搬移 / 对话通知 / 复制会话 ID / 一键同步记录。
+- [dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) - 看清 agent 此刻真正能触达哪些技能与工具——真实的在上下文状态（已加载/已截断/已挤出），并按会话开关。
 ## IDE & Clients
 
 - [Blue](https://github.com/dsh-blue/blue) - DeepSeek Harness 交互式 TUI 插件：基于 Cordis bundle 的 pi-tui 渲染器，支持流式转录、工具调用卡片、审批浮层、会话管理与主题。


### PR DESCRIPTION
Adds [dsh-capability-panel](https://github.com/pure-craft/dsh-capability-panel) to the Dashboards & Session UX category in both README.md and README.zh-CN.md.

**What it does:** A panel that shows which skills and tools your agent can actually reach right now — true in-context state (loaded/truncated/evicted) — with per-session on/off switches.

- npm package: [`dsh-capability-panel`](https://www.npmjs.com/package/dsh-capability-panel) (v1.1.0, published)
- License: MIT