### PR TITLE
Add jigjoy-ai/baro-dsh (verified multi-story delegation)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Management panel: Settings → Plugins.
 - [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) - Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.
 
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) - Generates session titles from user and assistant messages using a separate LLM request with a configurable input budget; refreshes after completed turns, preserves manual titles, and skips subagent and fork sessions by default.
+- [jigjoy-ai/baro-dsh](https://github.com/jigjoy-ai/baro/tree/main/packages/baro-dsh) - baro as a subagent provider: delegate a multi-story goal and get a plan, parallel coding agents, independent per-story review and a verified outcome (tests run, goal invariants attested, merged commits), with a live run panel (phase, stories, milestones) in the sidebar.
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,6 +125,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) - 定时任务：用 cron 表达式定时执行提示词，到点自动开一个新 agent 会话替你干活，支持绑定工作区、手动立即执行与会话自动命名。
 
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) - 通过独立 LLM 请求根据用户与助手消息生成会话标题，输入预算可配置；已完成轮次后刷新，保留手动标题，默认跳过子代理与 fork 会话。
+- [jigjoy-ai/baro-dsh](https://github.com/jigjoy-ai/baro/tree/main/packages/baro-dsh) - 将 baro 作为子代理提供者：委派一个多故事目标，获得计划、并行编码代理、独立的逐故事评审和经验证的结果（已运行测试、已认证目标不变量、已合并提交）；侧边栏实时显示运行面板（阶段、故事、里程碑）。
 
 ## Context & Search
 


### PR DESCRIPTION
Adds baro-dsh to Agents & Orchestration (EN + zh-CN).

baro-dsh makes baro a dsh subagent provider: an agent delegates a multi-story goal with the `baro` tool; baro plans it into stories, runs coding agents in parallel, reviews each story independently and returns a verified outcome (tests run, goal invariants attested, merged commits). A sidebar panel shows the run live.

Repo: https://github.com/jigjoy-ai/baro/tree/main/packages/baro-dsh (MIT, topic `dsh-plugin`), npm: `baro-dsh`.