### PR TITLE
docs: add dsh-unitverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -872,6 +872,8 @@ Management panel: Settings → Plugins.
 - [dsh-overlay-check](https://github.com/taltara/mddl-harness/tree/main/packages/overlay-check) - Offline overlay safety checks as a zero-dependency library: resolvability preflight, confined managed-block writes, a readable diff, and a warning that `agent-presets.roots` is discarded at boot (deepseek-harness#403).
 - [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) - TickTick (Dida365) task bridge: a session-header task panel and curated agent tools over the official TickTick MCP endpoint.
 
+- [dsh-unitverse](https://github.com/runcat-tommy/dsh-unitverse) - Unit conversion across 10 categories and 82 units (metric, imperial/US customary, Chinese) via a `convert` tool that accepts English and Chinese unit names and converts temperature differences with a Δ prefix, plus a locale-aware Unit Converter tab in the DSH web view.
+
 ## Related
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue aggregation hub.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -871,6 +871,8 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-overlay-check](https://github.com/taltara/mddl-harness/tree/main/packages/overlay-check) - 零依赖的离线覆盖层安全检查库：可解析性预检、受限的托管块写入、可读 diff，并会提示 `agent-presets.roots` 在启动时会被丢弃（deepseek-harness#403）。
 - [dsh-ticktick](https://github.com/PerryLink/dsh-ticktick) - TickTick（滴答清单）任务桥：会话页头部任务面板与精选代理工具，走官方 TickTick MCP 端点。
 
+- [dsh-unitverse](https://github.com/runcat-tommy/dsh-unitverse) - 单位换算：一个 `convert` 工具覆盖十大类共 82 个单位（公制、英制/美制、中国市制），支持中英文单位名与温差（Δ）前缀换算，并在 DSH Web 会话视图中提供跟随中英文界面语言的「单位换算」标签页。
+
 ## Related
 
 - [dsh-external/issues](https://github.com/dsh-external/issues) - Issue 聚合仓库


### PR DESCRIPTION
Adds **dsh-unitverse** to the **Tools & Utilities** list in both `README.md` (English) and `README.zh-CN.md` (Chinese) — same entry, translated description, as CONTRIBUTING asks.

**dsh-unitverse** — unit conversion across 10 categories and 82 units (metric, imperial/US customary, Chinese) via a `convert` tool that accepts English and Chinese unit names and converts temperature differences with a Δ prefix, plus a locale-aware Unit Converter tab in the DSH web view.

Details:

- Repo: https://github.com/runcat-tommy/dsh-unitverse
- npm: [`dsh-unitverse`](https://www.npmjs.com/package/dsh-unitverse) — `repository` points back at this repo
- Declares `dsh.bundle` (`cordis.patch.yml` at the root), MIT, runtime artifacts committed, no lifecycle scripts
- Unit tokens are case-insensitive and accept symbols, English full names and Chinese names (`km` / `kilometer` / `千米` / `公里`)
- The web view ships one module per category, so units of different categories can never be mixed

It sits next to `dsh-case` and `dsh-file-convert` — the closest neighbours in that section.

---

新增：在 **Tools & Utilities** 分类的 `README.md` 与 `README.zh-CN.md` 中同步加入 dsh-unitverse（同一词条，描述对译）。该插件提供一个 `convert` 工具，覆盖十大类共 82 个单位（公制、英制/美制、中国市制），支持中英文单位名与温差（Δ）前缀换算，并在 DSH Web 会话视图中提供跟随界面语言的「单位换算」标签页。
