### PR TITLE
docs: add dsplugin.app to Related (en + zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -879,6 +879,7 @@ Management panel: Settings → Plugins.
 - [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 173 English-canonical, source-backed guides with 202 localized documents, an 82-resource Agent-first [Awesome resource map](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html), local-browser [Install Doctor](https://sandbaseai.github.io/deepseek-harness-handbook/install-doctor.html), and [Failure Router](https://sandbaseai.github.io/deepseek-harness-handbook/diagnose.html).
 - [liyupi/ai-guide](https://github.com/liyupi/ai-guide) - Chinese Vibe Coding handbook with a dedicated DeepSeek Harness section: getting started, server deployment, agent presets, minimal-mode field test, and curated plugins.
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI-compatible endpoint with free DeepSeek V4 Pro/Flash daily quotas; point DEEPSEEK_BASE_URL at it, no payment info required.
+- [dsh-plugin-registry](https://github.com/vbarter/dsh-plugin-registry) - Unofficial community DeepSeek Harness plugin directory / registry at [dsplugin.app](https://dsplugin.app/): browse and publish with Manifest / `dsh.bundle` checks.
 - [DeepSeek](https://deepseek.com) - Official site.
 
 ### Friendly links

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -878,6 +878,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [DeepSeek Harness Handbook](https://github.com/sandbaseai/deepseek-harness-handbook) - 从 Agent 视角讲解 DSH 运行、扩展与排障的来源可追溯手册，提供 162 篇英文 canonical 指南、189 份多语言文档、可搜索的 [Awesome 资源地图](https://sandbaseai.github.io/deepseek-harness-handbook/awesome-deepseek-harness-resources.html)，以及 Install Doctor 和 Failure Router 速查工具
 - [liyupi/ai-guide](https://github.com/liyupi/ai-guide) - 中文 Vibe Coding 教程，设有 DeepSeek Harness 专题：保姆级入门、服务器部署、Agent 预设详解、极简模式实测与精选插件推荐。
 - [TeamoRouter](https://teamorouter.com/docs/install-deepseek-harness) - OpenAI 兼容接入点，提供免费的 DeepSeek V4 Pro/Flash 每日配额；把 DEEPSEEK_BASE_URL 指向它即可，无需支付信息。
+- [dsh-plugin-registry](https://github.com/vbarter/dsh-plugin-registry) - 非官方社区 DeepSeek Harness 插件目录 / 注册表（[dsplugin.app](https://dsplugin.app/)）：浏览与发布，含 Manifest / `dsh.bundle` 校验。
 - [DeepSeek](https://deepseek.com) - 官方入口
 
 ### 友情链接


### PR DESCRIPTION
## Summary
- Add bilingual Related entry for **https://dsplugin.app/** ([vbarter/dsh-plugin-registry](https://github.com/vbarter/dsh-plugin-registry)).
- Tone: **unofficial community DeepSeek Harness plugin directory / registry** with Manifest / `dsh.bundle` checks.
- Updates both `README.md` and `README.zh-CN.md`.

## Section type
**Related** (discovery / resources) — not inserted as an installable plugin row.

## Notes
Companion outreach elsewhere uses Marketplaces & Discovery where that section exists; this list’s Related section is the closest fit for a non-plugin directory site.