### PR TITLE
docs: update dsh-panda-calendar entry (on-this-day history + timestamp converter)

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,7 @@ Management panel: Settings → Plugins.
 - [dsh-billing-tui](https://github.com/Ethanz11-creat/dsh-billing-tui) - Real-time token/cost billing with official DeepSeek peak/off-peak pricing: TUI status line and a whale ASCII receipt via /billing.
 
 - [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) - Peak/valley billing dock and usage analytics: token/cost/model stats, trend and token-mix charts, latest-20-turns records, global time/session/model filters.
-- [runcat-tommy/dsh-panda-calendar](https://github.com/runcat-tommy/dsh-panda-calendar) - Panda Calendar (熊猫日历) conversation-view tab: solar/lunar dates, ganzhi, Chinese zodiac, solar terms, festivals, China public holidays incl. make-up workdays, and multi-city weather; free data sources, no API key.
+- [runcat-tommy/dsh-panda-calendar](https://github.com/runcat-tommy/dsh-panda-calendar) - Panda Calendar (熊猫日历) conversation-view tab: solar/lunar dates, ganzhi, Chinese zodiac, solar terms, festivals, China public holidays incl. make-up workdays, multi-city weather, an epoch↔date timestamp converter with a time-zone picker, and bundled offline "on this day" history; free data sources, no API key.
 - [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) - Full-control session management for DSH Web: archive, guaranteed physical delete (tombstone anti-resurrection), drag-and-drop workspace moves, conversation notifications, copy session ID and one-click record sync.
 ## IDE & Clients
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -383,7 +383,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [dsh-billing-tui](https://github.com/Ethanz11-creat/dsh-billing-tui) - 实时 token 计费，按 DeepSeek 官方峰谷定价：TUI 状态行实时显示费用，/billing 打印鲸鱼 ASCII 账单小票。
 
 - [woosh2010/dsh-usage-dashboard](https://github.com/woosh2010/dsh-usage-dashboard) - 峰谷计费坞 + 用量分析仪表盘：token/成本/模型统计、成本趋势与 Token 结构图表、最近 20 轮明细，支持时间/会话/模型全局筛选与账户余额。
-- [runcat-tommy/dsh-panda-calendar](https://github.com/runcat-tommy/dsh-panda-calendar) - 熊猫日历会话视图标签页：公历/农历、干支、生肖、节气、传统与外国节日、中国法定节假日（含调休）、多城市天气；免费数据源，无需 API Key。
+- [runcat-tommy/dsh-panda-calendar](https://github.com/runcat-tommy/dsh-panda-calendar) - 熊猫日历会话视图标签页：公历/农历、干支、生肖、节气、传统与外国节日、中国法定节假日（含调休）、多城市天气、时间戳转换（秒/毫秒 ↔ 年月日时分秒，可选时区）与内置离线的「历史上的今天」；免费数据源，无需 API Key。
 - [dsh-session-enhance](https://github.com/Tinger-X/dsh-session-enhance) - DSH Web 会话管理增强插件：归档管理 / 真实物理删除（墓碑防复活）/ 跨工作区拖拽搬移 / 对话通知 / 复制会话 ID / 一键同步记录。
 ## IDE & Clients
 


### PR DESCRIPTION
Refreshes our own existing entry (previously added in #561) so it reflects the features the plugin ships today. Only the single line for `runcat-tommy/dsh-panda-calendar` changes, in both READMEs (same entry, translated).

- `README.md`: adds the epoch↔date timestamp converter (with a time-zone picker) and the bundled offline "on this day" history to the existing one-line description.
- `README.zh-CN.md`: the same addition in Chinese（时间戳转换 + 内置离线的「历史上的今天」）.

`dsh-panda-calendar` v1.2.3 is on npm (`latest`), the repo carries the `dsh-plugin` topic, declares `dsh.bundle.patch: ./cordis.patch.yml`, and everything in the description is verifiable in the code and README (the converter is a pure client-side card; the history snapshot is bundled, so both work offline).

No new entry is added, no other entry is touched.

---

同步我方已有条目（原条目见 #561），让其反映插件当前实际功能：仅改动 `runcat-tommy/dsh-panda-calendar` 这一行，中英两个 README 同步对译。

- `README.md`：在原有单行描述后补上「epoch↔date 时间戳转换（可选时区）」与「内置离线『历史上的今天』」。
- `README.zh-CN.md`：中文侧同步补上「时间戳转换（秒/毫秒 ↔ 年月日时分秒，可选时区）」与「内置离线的『历史上的今天』」。

插件 v1.2.3 已发布 npm（`latest`），仓库带 `dsh-plugin` topic 并声明 `dsh.bundle.patch: ./cordis.patch.yml`；描述中的功能均可在代码与 README 中核对（时间戳转换为纯前端卡片、历史数据为内置快照，两者断网可用）。

未新增条目，未改动任何其他条目。
