### PR TITLE
docs: add zuoyunlai/lunheng-article-pipeline-dsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Management panel: Settings → Plugins.
 - [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) - Scheduled tasks: run a prompt on cron schedules, each run opens a new agent session to do the work, with workspace binding, manual run, session auto-naming, and a fullscreen task management page.
 
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) - Generates session titles from user and assistant messages using a separate LLM request with a configurable input budget; refreshes after completed turns, preserves manual titles, and skips subagent and fork sessions by default.
+- [zuoyunlai/lunheng-article-pipeline-dsh](https://github.com/zuoyunlai/lunheng-article-pipeline-dsh) - Long-form writing pipeline bundle: nine independent roles (literature, data and case retrieval, analysis, drafting, critique, audit, final check, peer review) across six phases with four human checkpoints, triangular evidence verification, a 23-check mechanical final gate, a G0-G14 audit, and peer-review scoring with journal matching. Install: `dsh plugin add lunheng-article-pipeline`.
 
 ## Context & Search
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -125,6 +125,7 @@ dsh plugin --profile web add "github:owner/repo#ref"
 - [weibaohui/dsh-tasks](https://github.com/weibaohui/dsh-tasks) - 定时任务：用 cron 表达式定时执行提示词，到点自动开一个新 agent 会话替你干活，支持绑定工作区、手动立即执行与会话自动命名。
 
 - [weibaohui/dsh-smart-title](https://github.com/weibaohui/dsh-smart-title) - 通过独立 LLM 请求根据用户与助手消息生成会话标题，输入预算可配置；已完成轮次后刷新，保留手动标题，默认跳过子代理与 fork 会话。
+- [zuoyunlai/lunheng-article-pipeline-dsh](https://github.com/zuoyunlai/lunheng-article-pipeline-dsh) - 深度长文写作流水线 bundle：9 个独立角色（文献 / 数据 / 案例检索、分析、写作、批判、审计、终检、同行评审）跨 6 个阶段，含 4 个人在环节点、三角验证、M 门 23 项机械终检、G0-G14 独立审计与审稿评分/期刊匹配。安装：`dsh plugin add lunheng-article-pipeline`。
 
 ## Context & Search
 


### PR DESCRIPTION
Adds one entry to **Agents & Orchestration** in both languages (`README.md` + `README.zh-CN.md`), pure insertions, `CATALOG.md` untouched.

`zuoyunlai/lunheng-article-pipeline-dsh` — long-form writing pipeline shipped as a DSH bundle. The one-liner states only what the package ships: nine independent roles (literature / data / case retrieval, analysis, drafting, critique, audit, final check, peer review) across six phases, four human checkpoints, triangular evidence verification, a 23-check mechanical final gate (M-Form 11 + M-Exist 10 + M-Integrity 2), a G0-G14 audit, and peer-review scoring with journal matching.

Install path, if you want to check it mechanically: `package.json` declares `"dsh": { "bundle": { "patch": "./cordis.patch.yml" } }` with the patch committed at the repo root, the repo carries the `dsh-plugin` topic, and the package is published on npm (`lunheng-article-pipeline@18.0.1`). Verified against `@deepseek-ai/dsh` `0.1.2-rc.1`: install into a fresh profile → `--dump-config` shows the bundle layer, the package's own loader row and its three tiered `@deepseek-ai/dsh-tool-subagent` rows → the installed entry registers the skill.
